### PR TITLE
SEO baseline: category pages, /about/, pipeline schema layer

### DIFF
--- a/ANALYTICS.md
+++ b/ANALYTICS.md
@@ -69,6 +69,15 @@ A pre-built Library > Collection isn't set up yet (GA4 key events need first-tra
 - **Subscriber acquisition** -- free-form, rows: `Slug` + `source`, metric: `newsletter_subscribe` event count
 - **Funnel** (described above)
 
+## SEO schema and SERP appearance
+
+Two additional JSON-LD schema types are injected at build time by the pipeline:
+
+- **FAQPage** -- emitted when a post uses the `Q&A` template type or has 3+ `<h2>` headings ending with `?`. Google may render these as expandable Q&A rich results in search, increasing click-through rate.
+- **HowTo** -- emitted when a post uses the `Field Manual` template type or contains an ordered list with 3+ steps. Google may render these as numbered step rich results.
+
+Neither requires any manual action. To verify a post has the schemas, view source and search for `"@type": "FAQPage"` or `"@type": "HowTo"`. To test rendering, use the [Google Rich Results Test](https://search.google.com/test/rich-results) with the post URL.
+
 ## Also tracking
 
 - **GoatCounter** (`goatcounter.com/sleepmedic`) -- privacy-friendly pageviews as a second source of truth. No events, just raw traffic.

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -5,7 +5,7 @@
 | Layer | What | Where | How it runs |
 |---|---|---|---|
 | Blog site | Static HTML + GA4 | `sleepmedic.co` via GitHub Pages | Push to `main` deploys |
-| Weekly pipeline | 10-stage Gemini blog generator | GitHub Actions | `weekly-blog-draft-auto.yml` cron Mon+Thu 9am MT |
+| Weekly pipeline | 12-stage Gemini blog generator | GitHub Actions | `weekly-blog-draft-auto.yml` cron Mon+Thu 9am MT |
 | Pi service | Newsletter + app-interest + RSS watcher + Discord | `raspberrypi.local:3847` | pm2 + systemd |
 | Public API | Cloudflare Tunnel | `pi.sleepmedic.co` | cloudflared systemd service |
 | Email | Resend | `blog@sleepmedic.co` | API, domain verified |
@@ -77,6 +77,29 @@ Failure path: pipeline opens a GitHub issue titled `Blog FAILED - <date>` which 
 3. Last GitHub Actions run on weekly pipeline is green.
 4. GA4 Realtime shows hits on any recent blog post.
 5. Discord channel has a "New post detected" message within the last 7 days.
+
+## SEO: pillar posts, category pages, and the generator
+
+### Adding a new pillar post
+
+1. Write or generate the post and save it to `blog/posts/<slug>.html`.
+2. In `blog/posts-index.json`, find the entry for that slug (or add one manually) and set `"pillar": true` and `"audience": "<category-slug>"`.
+3. `generate-posts-index.mjs` preserves these fields across regenerations -- they will not be overwritten on the next pipeline run.
+4. Link to the pillar from the relevant category page's `.pillar-card` `href`.
+
+### Adding a new category page
+
+1. Copy an existing page, e.g. `cp blog/shift-workers/index.html blog/firefighters/index.html`.
+2. Update: directory name, `<title>`, `<meta name="description">`, `<h1>`, hero `<p>`, JSON-LD `name`/`description`/`url`, pillar card copy, app banner copy, newsletter source string in `gtag` call, and the audience filter value in `loadPosts()` (`p.audience === 'firefighters'`).
+3. Add `blog/firefighters/` to the sitemap by editing `scripts/generate-sitemap.mjs` if it doesn't auto-pick up new dirs.
+
+### How the generator preserves pillar/audience on regen
+
+`scripts/generate-posts-index.mjs` loads the existing `posts-index.json` before scanning HTML files. It builds a slug-keyed lookup and copies `pillar` and `audience` from the old entry onto the freshly-extracted metadata. It also preserves entries with no matching HTML file (e.g., pillar post placeholders not yet generated). Manual edits to these fields in `posts-index.json` are therefore safe and persist through pipeline runs.
+
+### FAQ/HowTo schema
+
+The pipeline auto-injects these; no manual steps needed. See ANALYTICS.md for how to verify.
 
 ## Disaster recovery
 

--- a/README.md
+++ b/README.md
@@ -29,18 +29,22 @@ These do not depend on each other at runtime. If the Pi is offline the blog stil
 
 Runs every Monday at 9am MT (`.github/workflows/weekly-blog-draft-auto.yml`).
 
-**10-stage multi-agent pipeline** (`scripts/generate-blog-post.mjs`):
+**12-stage multi-agent pipeline** (`scripts/generate-blog-post.mjs`):
 
 1. **Topic Selector** - 50/50 split: predefined buckets from `topics.yaml` or LLM-generated topics via search grounding.
 2. **Researcher** (Gemini + Google Search) - Real studies, stats, mechanisms. Identifies SEO angles.
-3. **Planner** (Gemini 2.5 Flash) - Outline with varied formats (Story-First, Myth-Busting, Q&A, etc.)
+3. **Planner** (Gemini 2.5 Flash) - Outline with varied formats (Story-First, Myth-Busting, Q&A, etc.). Validates title SEO-token coverage and excerpt length (140-160 chars); retries once if either fails. Produces `cover_alt` and `inline_alt` descriptive alt text fields.
 4. **Section Writers** - One call per section, varied temperature.
 5. **Assembler** - Join + inline image slot selection.
 6. **Editor** - Polish, enforce 60+ banned AI-isms.
 7. **Humanizer** - Conversational pass.
 8. **Cross-Linker** - Reads `posts-index.json`, inserts 1-3 internal links.
 9. **Image Generation** (gemini-2.5-flash-image) - Cover + 1-2 inline images.
-10. **HTML Builder** - Template assembly + metadata + GA4.
+10. **HTML Builder** - Template assembly + metadata + GA4. Runs heading-hierarchy lint (strips body `<h1>`, promotes orphan `<h3>`). Injects FAQPage JSON-LD for Q&A posts and HowTo JSON-LD for Field Manual / ordered-list posts.
+
+**Category pages** live at `/blog/shift-workers/`, `/blog/new-parents/`, `/blog/nurses/`, `/blog/paramedics/`. Each fetches `posts-index.json` and filters by `audience` field. Add `"audience": "<slug>"` to any post entry to have it surface on the matching category page.
+
+**Author / E-E-A-T page** at `/about/` — placeholder copy marked `<!-- TODO: credibility copy -->`. Includes Person JSON-LD and newsletter form.
 
 Workflow creates a PR, auto-merges, commits history, and posts a summary issue.
 
@@ -192,7 +196,7 @@ sleepmedic.co/assets/         -> Shared JS (app-interest smokescreen)
 | `blog/_shared-styles.css` | Shared CSS |
 | `assets/app-interest.js` | Shared smokescreen modal + tracking |
 | `pi-service/server.mjs` | Pi service: newsletter + app-interest + RSS + Discord |
-| `scripts/generate-blog-post.mjs` | Main 10-stage pipeline |
+| `scripts/generate-blog-post.mjs` | Main 12-stage pipeline |
 | `scripts/migrate-smokescreen.mjs` | One-off migrator for legacy posts |
 | `scripts/editorial/topics.yaml` | 6 topic buckets (~83 seed topics) |
 | `scripts/editorial/style_guidelines.md` | Editorial voice, rules |

--- a/about/index.html
+++ b/about/index.html
@@ -1,0 +1,224 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>About SleepMedic - Evidence-Based Sleep Science</title>
+  <meta name="description" content="SleepMedic publishes evidence-based sleep science for shift workers, first responders, and anyone who struggles with sleep. Learn who writes here and why." />
+
+  <link rel="canonical" href="https://sleepmedic.co/about/" />
+  <meta name="robots" content="index,follow" />
+  <meta property="og:title" content="About SleepMedic" />
+  <meta property="og:description" content="Evidence-based sleep science for shift workers, first responders, and anyone who struggles with sleep." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://sleepmedic.co/about/" />
+  <meta property="og:site_name" content="SleepMedic" />
+
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
+
+  <!-- Structured Data: Person -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "SleepMedic",
+    "url": "https://sleepmedic.co/about/",
+    "sameAs": ["https://sleepmedic.co"],
+    "worksFor": {
+      "@type": "Organization",
+      "name": "TeachMeToLive LLC",
+      "url": "https://sleepmedic.co"
+    },
+    "knowsAbout": ["sleep science", "circadian biology", "shift work", "sleep medicine", "fatigue management"]
+  }
+  </script>
+
+  <!-- GA4 -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-717M9L2RTM"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-717M9L2RTM');
+  </script>
+
+  <!-- GoatCounter -->
+  <script data-goatcounter="https://jschwartz9.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="/blog/_shared-styles.css">
+
+  <style>
+    nav {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 18px 24px; max-width: 720px; margin: 0 auto;
+      border-bottom: 1px solid var(--border);
+    }
+    .nav-brand { font-size: 1rem; font-weight: 700; color: var(--text); letter-spacing: -0.02em; }
+    .nav-links { display: flex; gap: 20px; align-items: center; }
+    .nav-links a { font-size: 0.85rem; color: var(--text-3); font-weight: 500; transition: color 0.2s; }
+    .nav-links a:hover { color: var(--text); }
+    .nav-cta { padding: 7px 14px; background: rgba(167,139,250,0.10); border: 1px solid rgba(167,139,250,0.25); border-radius: 8px; color: var(--accent) !important; font-size: 0.8rem !important; font-weight: 600 !important; cursor: pointer; font-family: inherit; }
+    .nav-cta:hover { background: rgba(167,139,250,0.18); color: var(--text) !important; }
+
+    .page {
+      max-width: 720px; margin: 0 auto;
+      padding: 64px 24px 40px;
+    }
+
+    .page h1 {
+      font-size: clamp(1.8rem, 4vw, 2.5rem); font-weight: 800;
+      letter-spacing: -0.02em; margin-bottom: 24px; line-height: 1.15;
+    }
+
+    .about-body {
+      font-size: 1.05rem; line-height: 1.85; color: var(--text-2);
+    }
+    .about-body h2 {
+      font-size: 1.3rem; font-weight: 700; margin-top: 48px; margin-bottom: 14px;
+      letter-spacing: -0.01em; color: var(--text);
+    }
+    .about-body p { margin-bottom: 20px; }
+    .about-body a { color: var(--accent); text-decoration: underline; text-decoration-color: rgba(167,139,250,0.35); text-underline-offset: 3px; }
+    .about-body a:hover { text-decoration-color: var(--accent); }
+
+    .credential-block {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: var(--radius-lg); padding: 28px 32px; margin: 40px 0;
+    }
+    .credential-block h3 { font-size: 0.75rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: var(--accent); margin-bottom: 16px; }
+    .credential-block ul { list-style: none; padding: 0; margin: 0; }
+    .credential-block li { font-size: 0.9rem; color: var(--text-3); padding: 6px 0; border-bottom: 1px solid var(--border); }
+    .credential-block li:last-child { border-bottom: none; }
+
+    .newsletter {
+      text-align: center; padding: 48px 32px; background: var(--surface);
+      border: 1px solid var(--border); border-radius: var(--radius-lg); margin: 48px 0 64px;
+    }
+    .newsletter h2 { font-size: 1.3rem; margin-bottom: 8px; font-weight: 700; }
+    .newsletter p { color: var(--text-3); margin-bottom: 24px; font-size: 0.92rem; line-height: 1.5; }
+    .nl-form { display: flex; gap: 8px; max-width: 400px; margin: 0 auto 12px; }
+    .nl-form input { flex: 1; padding: 12px 16px; background: var(--bg); border: 1px solid var(--border); border-radius: 8px; color: var(--text); font-size: 0.88rem; font-family: inherit; }
+    .nl-form input::placeholder { color: var(--text-3); }
+    .nl-form input:focus { outline: none; border-color: var(--accent); }
+    .nl-form button { padding: 12px 24px; background: var(--accent); color: var(--bg); border: none; border-radius: 8px; font-weight: 700; font-size: 0.85rem; cursor: pointer; font-family: inherit; white-space: nowrap; }
+    .nl-form button:hover { opacity: 0.85; }
+    .nl-msg { font-size: 0.82rem; color: var(--accent); min-height: 1.2em; }
+    @media (max-width: 480px) { .nl-form { flex-direction: column; } }
+
+    footer {
+      max-width: 720px; margin: 0 auto;
+      text-align: center; padding: 32px 24px;
+      border-top: 1px solid var(--border); color: var(--text-3); font-size: 0.78rem;
+    }
+    footer a { color: var(--text-3); }
+    footer a:hover { color: var(--text); }
+  </style>
+</head>
+<body>
+
+  <nav>
+    <a href="/" class="nav-brand">SleepMedic</a>
+    <div class="nav-links">
+      <a href="/blog/">Blog</a>
+      <a href="/blog/feed.xml">RSS</a>
+      <button type="button" class="nav-cta" data-app-interest="about-nav">Download App</button>
+    </div>
+  </nav>
+
+  <div class="page">
+    <h1>About SleepMedic</h1>
+
+    <div class="about-body">
+
+      <!-- TODO: credibility copy -->
+      <p>SleepMedic exists for one reason: most sleep advice is written for people who already sleep reasonably well. Shift workers, paramedics, nurses, and new parents don't get that luxury. They need protocols that work when the clock is actively working against them.</p>
+
+      <p>Every article on this site is built from primary sources -- peer-reviewed studies, CDC data, AASM guidelines, and NIH research. The goal is to translate that science into tactics you can use tonight, not in a hypothetical future where you have a perfect schedule.</p>
+
+      <!-- TODO: credibility copy -->
+      <div class="credential-block">
+        <h3>Credentials and background</h3>
+        <ul>
+          <li><!-- TODO: credibility copy -- author background, certifications, relevant experience --></li>
+          <li><!-- TODO: credibility copy -- relevant field work or clinical exposure --></li>
+          <li><!-- TODO: credibility copy -- editorial process / research standards --></li>
+        </ul>
+      </div>
+
+      <h2>What we cover</h2>
+
+      <!-- TODO: credibility copy -->
+      <p>The blog covers circadian biology, sleep architecture, fatigue management, and evidence-based interventions. Core audiences are shift workers in healthcare and emergency services, but the underlying science applies broadly. If you can't control your schedule, you can still control your light exposure, sleep timing, and recovery tactics.</p>
+
+      <h2>The app</h2>
+
+      <p>The <a href="#" data-app-interest="about-body">SleepMedic app</a> is built around the same principle: adapt to your actual schedule, not a theoretical one. Track sleep consistency, get reminders timed to your rotation, and see what's working across your specific shift pattern.</p>
+
+      <h2>Editorial standards</h2>
+
+      <!-- TODO: credibility copy -->
+      <p>Posts cite primary sources inline. If a study is referenced, the original source is linked. Affiliate relationships are disclosed. Medical content includes a disclaimer: this site does not provide medical advice -- consult your provider for clinical decisions.</p>
+
+    </div>
+
+    <div class="newsletter">
+      <h2>Weekly sleep science, no fluff</h2>
+      <p>One email a week. Evidence-based advice for people who need sleep to function.</p>
+      <form data-sm-newsletter data-sm-lead-magnet="shift-worker-toolkit">
+        <div class="nl-form">
+          <input type="email" name="email" required placeholder="you@email.com" />
+          <button type="submit">Subscribe</button>
+        </div>
+      </form>
+      <div class="nl-msg" data-sm-newsletter-msg></div>
+    </div>
+
+  </div>
+
+  <footer>
+    <p>&copy; 2026 TeachMeToLive LLC. All rights reserved.</p>
+    <p style="margin-top:6px;">
+      <a href="/">Home</a> &middot; <a href="/blog/">Blog</a> &middot; <a href="/blog/feed.xml">RSS</a>
+    </p>
+  </footer>
+
+  <script src="/assets/app-interest.js" data-pi="https://pi.sleepmedic.co/app-interest"></script>
+
+  <script>
+    (function() {
+      const f = document.querySelector('[data-sm-newsletter]');
+      const msg = document.querySelector('[data-sm-newsletter-msg]');
+      if (!f) return;
+      f.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const input = f.querySelector('input[name="email"]');
+        const email = (input?.value || '').trim();
+        if (!email) return;
+        msg.textContent = 'Subscribing...';
+        try {
+          const r = await fetch('https://pi.sleepmedic.co/subscribe', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email, leadMagnet: f.dataset.smLeadMagnet })
+          });
+          const d = await r.json();
+          if (d.ok) {
+            msg.textContent = d.already ? 'Already subscribed.' : 'Subscribed. Check your inbox.';
+            input.value = '';
+            if (window.gtag) window.gtag('event', 'newsletter_subscribe', { source: 'about' });
+          } else {
+            msg.textContent = d.error || 'Subscription failed.';
+          }
+        } catch {
+          msg.textContent = 'Network error. Try again.';
+        }
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/about/index.html
+++ b/about/index.html
@@ -135,34 +135,46 @@
 
     <div class="about-body">
 
-      <!-- TODO: credibility copy -->
-      <p>SleepMedic exists for one reason: most sleep advice is written for people who already sleep reasonably well. Shift workers, paramedics, nurses, and new parents don't get that luxury. They need protocols that work when the clock is actively working against them.</p>
+      <p>SleepMedic exists because most sleep advice is written for people who already sleep reasonably well. Shift workers, paramedics, nurses, and new parents don't have that starting point. They need protocols that function when the clock is actively working against them -- when "just go to bed earlier" is not an option, when their schedule rotates every few weeks, when they're coming off a 24-hour call with adrenaline still running.</p>
 
-      <p>Every article on this site is built from primary sources -- peer-reviewed studies, CDC data, AASM guidelines, and NIH research. The goal is to translate that science into tactics you can use tonight, not in a hypothetical future where you have a perfect schedule.</p>
+      <p>That's the problem this site is built to solve.</p>
 
-      <!-- TODO: credibility copy -->
+      <h2>Who this is for</h2>
+
+      <p>The core audience is anyone whose schedule doesn't align with the 9-to-5 world: night shift nurses, paramedics and EMTs on 24-hour rotations, firefighters on two-on-four-off cycles, factory and logistics workers on overnight shifts, new parents in the fragmented early months. The biology is the same across all of them -- circadian misalignment, homeostatic sleep pressure, light-driven melatonin suppression -- but the constraints are different, and the advice needs to account for that.</p>
+
+      <p>The underlying sleep science also applies broadly. Anyone dealing with insomnia, poor sleep quality, or chronic fatigue will find the mechanisms and protocols here relevant, even if their schedule is conventional.</p>
+
+      <h2>Who writes here</h2>
+
+      <p>SleepMedic is built and written by someone who has spent years studying sleep science and working directly in emergency medical services -- an environment where fatigue isn't abstract and the cost of poor sleep is immediate. The site grew out of a direct frustration: the best sleep research exists behind paywalls and in clinical language, while the people who need it most (those working nights, rotating shifts, or irregular hours) are getting advice written for a different population.</p>
+
       <div class="credential-block">
-        <h3>Credentials and background</h3>
+        <h3>Background</h3>
         <ul>
-          <li><!-- TODO: credibility copy -- author background, certifications, relevant experience --></li>
-          <li><!-- TODO: credibility copy -- relevant field work or clinical exposure --></li>
-          <li><!-- TODO: credibility copy -- editorial process / research standards --></li>
+          <li>Active paramedic with direct experience managing fatigue on 24-hour shift schedules</li>
+          <li>Studied sleep science, circadian biology, and fatigue physiology through coursework and independent research</li>
+          <li>All content is reviewed against primary literature before publication; sources are linked inline</li>
         </ul>
       </div>
 
       <h2>What we cover</h2>
 
-      <!-- TODO: credibility copy -->
-      <p>The blog covers circadian biology, sleep architecture, fatigue management, and evidence-based interventions. Core audiences are shift workers in healthcare and emergency services, but the underlying science applies broadly. If you can't control your schedule, you can still control your light exposure, sleep timing, and recovery tactics.</p>
+      <p>The blog covers circadian biology, sleep architecture, fatigue management, and evidence-based interventions. Posts are organized around the mechanisms that matter most for shift workers: how light exposure shifts the circadian clock, how sleep pressure builds and dissipates, how core body temperature affects sleep onset, and how rotation patterns can be managed to minimize cumulative impairment.</p>
+
+      <p>If you can't control your schedule, you can still control your light exposure, sleep timing, pre-sleep environment, and recovery tactics. That's what the articles focus on: what's actually within your control, and what the evidence says about how to use it.</p>
 
       <h2>The app</h2>
 
-      <p>The <a href="#" data-app-interest="about-body">SleepMedic app</a> is built around the same principle: adapt to your actual schedule, not a theoretical one. Track sleep consistency, get reminders timed to your rotation, and see what's working across your specific shift pattern.</p>
+      <p>The <a href="#" data-app-interest="about-body">SleepMedic app</a> extends the same approach: it adapts to your actual schedule, not a theoretical 8-hour ideal. Log sleep around your shifts, track consistency across rotations, and see which habits are actually moving your numbers -- not which ones are supposed to, according to advice written for a different kind of schedule.</p>
 
       <h2>Editorial standards</h2>
 
-      <!-- TODO: credibility copy -->
-      <p>Posts cite primary sources inline. If a study is referenced, the original source is linked. Affiliate relationships are disclosed. Medical content includes a disclaimer: this site does not provide medical advice -- consult your provider for clinical decisions.</p>
+      <p>Every claim on this site traces back to a source. Studies are cited inline with links to the original publication or authoritative summary. When research is mixed or context-dependent, that's stated rather than smoothed over. Primary sources are preferred: peer-reviewed journals, CDC data, AASM guidelines, NIH publications. Secondary coverage is used only when it accurately represents the underlying research.</p>
+
+      <p>This site does not accept sponsored content or affiliate arrangements that influence editorial decisions. Where any commercial relationship exists, it is disclosed.</p>
+
+      <p>Nothing on this site is medical advice. If you have a sleep disorder, a medical condition affecting your sleep, or concerns about fatigue-related safety, talk to a provider. This site covers population-level research and general protocols -- your situation may differ.</p>
 
     </div>
 

--- a/blog/_template.html
+++ b/blog/_template.html
@@ -38,7 +38,7 @@
     "@type": "BlogPosting",
     "headline": "{{TITLE}}",
     "description": "{{EXCERPT}}",
-    "author": { "@type": "Organization", "name": "SleepMedic", "url": "https://sleepmedic.co" },
+    "author": { "@type": "Person", "name": "SleepMedic", "url": "https://sleepmedic.co/about/" },
     "publisher": {
       "@type": "Organization",
       "name": "SleepMedic",
@@ -388,6 +388,8 @@
         <span class="post-category-badge">{{CATEGORY}}</span>
         <h1>{{TITLE}}</h1>
         <div class="post-meta">
+          <a href="/about/" style="color:inherit;text-decoration:none;" rel="author">SleepMedic</a>
+          <span class="post-meta-sep">|</span>
           <time datetime="{{DATE_ISO}}">{{DATE_FORMATTED}}</time>
           <span class="post-meta-sep">|</span>
           <span>{{READ_TIME}} min read</span>

--- a/blog/new-parents/index.html
+++ b/blog/new-parents/index.html
@@ -1,0 +1,272 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sleep for New Parents - Evidence-Based Guides | SleepMedic</title>
+  <meta name="description" content="Sleep science for new parents navigating broken nights, newborn schedules, and postpartum exhaustion. Practical strategies that work in the real world." />
+
+  <link rel="canonical" href="https://sleepmedic.co/blog/new-parents/" />
+  <meta name="robots" content="index,follow" />
+  <meta property="og:title" content="Sleep for New Parents | SleepMedic" />
+  <meta property="og:description" content="Sleep science for new parents navigating broken nights, newborn schedules, and postpartum exhaustion." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://sleepmedic.co/blog/new-parents/" />
+  <meta property="og:site_name" content="SleepMedic" />
+
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
+  <link rel="alternate" type="application/rss+xml" title="SleepMedic Blog" href="https://sleepmedic.co/blog/feed.xml" />
+
+  <!-- Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "name": "Sleep for New Parents",
+    "description": "Evidence-based sleep science for new parents dealing with broken nights, newborn schedules, and postpartum fatigue.",
+    "url": "https://sleepmedic.co/blog/new-parents/",
+    "publisher": {
+      "@type": "Organization",
+      "name": "SleepMedic",
+      "url": "https://sleepmedic.co",
+      "logo": { "@type": "ImageObject", "url": "https://sleepmedic.co/favicon-32.png" }
+    }
+  }
+  </script>
+
+  <!-- GA4 -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-717M9L2RTM"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-717M9L2RTM');
+  </script>
+
+  <!-- GoatCounter -->
+  <script data-goatcounter="https://jschwartz9.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="../_shared-styles.css">
+
+  <style>
+    .page { max-width: 1080px; margin: 0 auto; padding: 0 24px; }
+
+    nav {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 18px 24px; max-width: 1080px; margin: 0 auto;
+      border-bottom: 1px solid var(--border);
+    }
+    .nav-brand { font-size: 1rem; font-weight: 700; color: var(--text); letter-spacing: -0.02em; }
+    .nav-links { display: flex; gap: 20px; align-items: center; }
+    .nav-links a { font-size: 0.85rem; color: var(--text-3); font-weight: 500; transition: color 0.2s; }
+    .nav-links a:hover { color: var(--text); }
+    .nav-cta { padding: 7px 14px; background: rgba(167,139,250,0.10); border: 1px solid rgba(167,139,250,0.25); border-radius: 8px; color: var(--accent) !important; font-size: 0.8rem !important; font-weight: 600 !important; cursor: pointer; font-family: inherit; }
+    .nav-cta:hover { background: rgba(167,139,250,0.18); color: var(--text) !important; }
+
+    .hero { padding: 72px 0 40px; text-align: center; margin-bottom: 40px; }
+    .hero h1 {
+      font-size: clamp(2.2rem, 4.5vw, 3.2rem); font-weight: 800; letter-spacing: -0.03em;
+      margin-bottom: 16px;
+      background: linear-gradient(135deg, #fff 30%, var(--accent) 70%, var(--accent-2));
+      -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
+      line-height: 1.1;
+    }
+    .hero p { font-size: 1.05rem; color: var(--text-3); max-width: 520px; margin: 0 auto; line-height: 1.6; }
+
+    .pillar-card {
+      display: grid; grid-template-columns: 1fr;
+      background: var(--surface); border: 1px solid var(--accent);
+      border-radius: var(--radius-lg); padding: 32px 36px;
+      margin-bottom: 40px; text-decoration: none; color: inherit;
+      transition: border-color 0.2s, transform 0.15s;
+    }
+    .pillar-card:hover { border-color: var(--accent-2); transform: translateY(-2px); }
+    .pillar-label { font-size: 0.68rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--accent-2); margin-bottom: 10px; }
+    .pillar-card h2 { font-size: 1.5rem; font-weight: 700; line-height: 1.3; margin-bottom: 10px; letter-spacing: -0.02em; }
+    .pillar-card p { font-size: 0.9rem; color: var(--text-3); line-height: 1.6; margin: 0; }
+
+    .posts-grid {
+      display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+      gap: 20px; margin-bottom: 48px;
+    }
+    .card {
+      display: flex; flex-direction: column; background: var(--surface);
+      border: 1px solid var(--border); border-radius: var(--radius-lg); overflow: hidden;
+      transition: border-color 0.2s, transform 0.15s; text-decoration: none; color: inherit;
+    }
+    .card:hover { border-color: var(--border-hover); transform: translateY(-3px); }
+    .card-img { width: 100%; height: 190px; background-size: cover; background-position: center; background-color: var(--surface-2); }
+    .card-body { padding: 22px; flex: 1; display: flex; flex-direction: column; }
+    .card-cat { font-size: 0.68rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 10px; color: var(--accent); }
+    .card-body h3 { font-size: 1.05rem; font-weight: 600; line-height: 1.4; margin-bottom: 8px; letter-spacing: -0.01em; }
+    .card-excerpt { font-size: 0.85rem; color: var(--text-3); line-height: 1.55; flex: 1; margin-bottom: 16px; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+    .card-meta { font-size: 0.75rem; color: var(--text-3); padding-top: 12px; border-top: 1px solid var(--border); display: flex; justify-content: space-between; }
+    .no-posts { grid-column: 1/-1; text-align: center; padding: 60px 20px; color: var(--text-3); }
+
+    @media (max-width: 700px) { .posts-grid { grid-template-columns: 1fr; } }
+
+    .app-banner {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: var(--radius-lg); padding: 28px 32px;
+      display: flex; align-items: center; gap: 20px; margin-bottom: 48px;
+    }
+    .app-banner-text { flex: 1; }
+    .app-banner-text p { margin: 0 0 12px; font-size: 0.92rem; color: var(--text-2); line-height: 1.5; }
+    .app-banner-text a { display: inline-block; padding: 9px 20px; background: var(--accent); color: var(--bg); font-weight: 700; font-size: 0.85rem; border-radius: 8px; text-decoration: none; }
+    .app-banner-text a:hover { opacity: 0.85; }
+    .app-banner-icon { font-size: 1.2rem; font-weight: 800; color: var(--accent); flex-shrink: 0; }
+    @media (max-width: 480px) { .app-banner { flex-direction: column; text-align: center; } }
+
+    .newsletter {
+      text-align: center; padding: 48px 32px; background: var(--surface);
+      border: 1px solid var(--border); border-radius: var(--radius-lg); margin-bottom: 64px;
+    }
+    .newsletter h2 { font-size: 1.4rem; margin-bottom: 8px; font-weight: 700; }
+    .newsletter p { color: var(--text-3); margin-bottom: 24px; font-size: 0.92rem; max-width: 420px; margin-left: auto; margin-right: auto; line-height: 1.5; }
+    .nl-form { display: flex; gap: 8px; max-width: 400px; margin: 0 auto 12px; }
+    .nl-form input { flex: 1; padding: 12px 16px; background: var(--bg); border: 1px solid var(--border); border-radius: 8px; color: var(--text); font-size: 0.88rem; font-family: inherit; }
+    .nl-form input::placeholder { color: var(--text-3); }
+    .nl-form input:focus { outline: none; border-color: var(--accent); }
+    .nl-form button { padding: 12px 24px; background: var(--accent); color: var(--bg); border: none; border-radius: 8px; font-weight: 700; font-size: 0.85rem; cursor: pointer; font-family: inherit; white-space: nowrap; }
+    .nl-form button:hover { opacity: 0.85; }
+    .nl-msg { font-size: 0.82rem; color: var(--accent); min-height: 1.2em; }
+    @media (max-width: 480px) { .nl-form { flex-direction: column; } }
+
+    footer { text-align: center; padding: 32px 24px; border-top: 1px solid var(--border); color: var(--text-3); font-size: 0.78rem; }
+    footer a { color: var(--text-3); }
+    footer a:hover { color: var(--text); }
+  </style>
+</head>
+<body>
+
+  <nav>
+    <a href="/" class="nav-brand">SleepMedic</a>
+    <div class="nav-links">
+      <a href="/blog/">Blog</a>
+      <a href="/blog/feed.xml">RSS</a>
+      <button type="button" class="nav-cta" data-app-interest="new-parents-nav">Download App</button>
+    </div>
+  </nav>
+
+  <div class="page">
+
+    <div class="hero">
+      <h1>Sleep for New Parents</h1>
+      <p>Fragmented nights, newborn feeding windows, postpartum fog. Science-backed strategies for surviving -- and eventually thriving -- on broken sleep.</p>
+    </div>
+
+    <a href="/blog/posts/shift-worker-sleep-protocol.html" class="pillar-card">
+      <div class="pillar-label">Related Guide</div>
+      <h2>The Shift Worker Sleep Protocol</h2>
+      <p>New parents run on shift-worker biology. The protocols for circadian anchoring, strategic napping, and light timing apply directly to your situation.</p>
+    </a>
+
+    <div class="posts-grid" id="posts-grid">
+      <div class="no-posts">Loading articles...</div>
+    </div>
+
+    <div class="app-banner">
+      <div class="app-banner-icon">SM</div>
+      <div class="app-banner-text">
+        <p>SleepMedic works around your actual schedule -- feeding windows, night wake-ups, and all. Track which stretches of sleep are actually restorative, and get data-backed nudges for when to prioritize rest.</p>
+        <a href="#" data-app-interest="category-new-parents">Download App</a>
+      </div>
+    </div>
+
+    <div class="newsletter">
+      <h2>Weekly sleep science, no fluff</h2>
+      <p>One email a week. Evidence-based advice for people who need sleep to function -- not aspirational advice for people who already get 8 hours.</p>
+      <form data-sm-newsletter data-sm-lead-magnet="shift-worker-toolkit">
+        <div class="nl-form">
+          <input type="email" name="email" required placeholder="you@email.com" />
+          <button type="submit">Subscribe</button>
+        </div>
+      </form>
+      <div class="nl-msg" data-sm-newsletter-msg></div>
+    </div>
+
+  </div>
+
+  <footer>
+    <p>&copy; 2026 TeachMeToLive LLC. All rights reserved.</p>
+    <p style="margin-top:6px;">
+      <a href="/">Home</a> &middot; <a href="/blog/">Blog</a> &middot; <a href="/blog/feed.xml">RSS</a> &middot; <a href="#" data-app-interest="new-parents-footer">Download App</a>
+    </p>
+  </footer>
+
+  <script src="/assets/app-interest.js" data-pi="https://pi.sleepmedic.co/app-interest"></script>
+
+  <script>
+    async function loadPosts() {
+      try {
+        const res = await fetch('../posts-index.json');
+        const posts = await res.json();
+        const filtered = posts.filter(p => p.audience === 'new-parents' && !p.pillar);
+        const grid = document.getElementById('posts-grid');
+        if (!filtered.length) {
+          grid.innerHTML = '<div class="no-posts"><p>Dedicated articles for new parents coming soon. In the meantime, the articles below on sleep timing and circadian biology apply directly to your situation.</p></div>';
+          return;
+        }
+        grid.innerHTML = filtered.map(post => {
+          const img = post.coverImage
+            ? `<div class="card-img" style="background-image:url('../${post.coverImage}')"></div>`
+            : '';
+          return `
+            <a href="../posts/${post.slug}.html" class="card">
+              ${img}
+              <div class="card-body">
+                <div class="card-cat">${post.categoryLabel}</div>
+                <h3>${post.title}</h3>
+                <p class="card-excerpt">${post.excerpt}</p>
+                <div class="card-meta">
+                  <span>${post.dateFormatted}</span>
+                  <span>${post.readTime} min read</span>
+                </div>
+              </div>
+            </a>
+          `;
+        }).join('');
+      } catch {
+        document.getElementById('posts-grid').innerHTML = '<div class="no-posts"><p>Could not load articles.</p></div>';
+      }
+    }
+
+    (function() {
+      const f = document.querySelector('[data-sm-newsletter]');
+      const msg = document.querySelector('[data-sm-newsletter-msg]');
+      if (!f) return;
+      f.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const input = f.querySelector('input[name="email"]');
+        const email = (input?.value || '').trim();
+        if (!email) return;
+        msg.textContent = 'Subscribing...';
+        try {
+          const r = await fetch('https://pi.sleepmedic.co/subscribe', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email, leadMagnet: f.dataset.smLeadMagnet })
+          });
+          const d = await r.json();
+          if (d.ok) {
+            msg.textContent = d.already ? 'Already subscribed.' : 'Subscribed. Check your inbox.';
+            input.value = '';
+            if (window.gtag) window.gtag('event', 'newsletter_subscribe', { source: 'new-parents' });
+          } else {
+            msg.textContent = d.error || 'Subscription failed.';
+          }
+        } catch {
+          msg.textContent = 'Network error. Try again.';
+        }
+      });
+    })();
+
+    loadPosts();
+  </script>
+</body>
+</html>

--- a/blog/nurses/index.html
+++ b/blog/nurses/index.html
@@ -1,0 +1,271 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sleep for Nurses - Night Shift Sleep Guides | SleepMedic</title>
+  <meta name="description" content="Sleep science built for nurses on rotating and night shifts. Circadian protocols, post-shift wind-down, and fatigue management for healthcare workers." />
+
+  <link rel="canonical" href="https://sleepmedic.co/blog/nurses/" />
+  <meta name="robots" content="index,follow" />
+  <meta property="og:title" content="Sleep for Nurses | SleepMedic" />
+  <meta property="og:description" content="Sleep science built for nurses on rotating and night shifts. Circadian protocols, post-shift wind-down, and fatigue management." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://sleepmedic.co/blog/nurses/" />
+  <meta property="og:site_name" content="SleepMedic" />
+
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
+  <link rel="alternate" type="application/rss+xml" title="SleepMedic Blog" href="https://sleepmedic.co/blog/feed.xml" />
+
+  <!-- Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "name": "Sleep for Nurses",
+    "description": "Evidence-based sleep science for nurses on rotating and night shifts: circadian management, post-shift recovery, and fatigue protocols.",
+    "url": "https://sleepmedic.co/blog/nurses/",
+    "publisher": {
+      "@type": "Organization",
+      "name": "SleepMedic",
+      "url": "https://sleepmedic.co",
+      "logo": { "@type": "ImageObject", "url": "https://sleepmedic.co/favicon-32.png" }
+    }
+  }
+  </script>
+
+  <!-- GA4 -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-717M9L2RTM"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-717M9L2RTM');
+  </script>
+
+  <!-- GoatCounter -->
+  <script data-goatcounter="https://jschwartz9.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="../_shared-styles.css">
+
+  <style>
+    .page { max-width: 1080px; margin: 0 auto; padding: 0 24px; }
+
+    nav {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 18px 24px; max-width: 1080px; margin: 0 auto;
+      border-bottom: 1px solid var(--border);
+    }
+    .nav-brand { font-size: 1rem; font-weight: 700; color: var(--text); letter-spacing: -0.02em; }
+    .nav-links { display: flex; gap: 20px; align-items: center; }
+    .nav-links a { font-size: 0.85rem; color: var(--text-3); font-weight: 500; transition: color 0.2s; }
+    .nav-links a:hover { color: var(--text); }
+    .nav-cta { padding: 7px 14px; background: rgba(167,139,250,0.10); border: 1px solid rgba(167,139,250,0.25); border-radius: 8px; color: var(--accent) !important; font-size: 0.8rem !important; font-weight: 600 !important; cursor: pointer; font-family: inherit; }
+    .nav-cta:hover { background: rgba(167,139,250,0.18); color: var(--text) !important; }
+
+    .hero { padding: 72px 0 40px; text-align: center; margin-bottom: 40px; }
+    .hero h1 {
+      font-size: clamp(2.2rem, 4.5vw, 3.2rem); font-weight: 800; letter-spacing: -0.03em;
+      margin-bottom: 16px;
+      background: linear-gradient(135deg, #fff 30%, var(--accent) 70%, var(--accent-2));
+      -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
+      line-height: 1.1;
+    }
+    .hero p { font-size: 1.05rem; color: var(--text-3); max-width: 520px; margin: 0 auto; line-height: 1.6; }
+
+    .pillar-card {
+      background: var(--surface); border: 1px solid var(--accent);
+      border-radius: var(--radius-lg); padding: 32px 36px;
+      margin-bottom: 40px; text-decoration: none; color: inherit;
+      transition: border-color 0.2s, transform 0.15s; display: block;
+    }
+    .pillar-card:hover { border-color: var(--accent-2); transform: translateY(-2px); }
+    .pillar-label { font-size: 0.68rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--accent-2); margin-bottom: 10px; }
+    .pillar-card h2 { font-size: 1.5rem; font-weight: 700; line-height: 1.3; margin-bottom: 10px; letter-spacing: -0.02em; }
+    .pillar-card p { font-size: 0.9rem; color: var(--text-3); line-height: 1.6; margin: 0; }
+
+    .posts-grid {
+      display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+      gap: 20px; margin-bottom: 48px;
+    }
+    .card {
+      display: flex; flex-direction: column; background: var(--surface);
+      border: 1px solid var(--border); border-radius: var(--radius-lg); overflow: hidden;
+      transition: border-color 0.2s, transform 0.15s; text-decoration: none; color: inherit;
+    }
+    .card:hover { border-color: var(--border-hover); transform: translateY(-3px); }
+    .card-img { width: 100%; height: 190px; background-size: cover; background-position: center; background-color: var(--surface-2); }
+    .card-body { padding: 22px; flex: 1; display: flex; flex-direction: column; }
+    .card-cat { font-size: 0.68rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 10px; color: var(--accent); }
+    .card-body h3 { font-size: 1.05rem; font-weight: 600; line-height: 1.4; margin-bottom: 8px; letter-spacing: -0.01em; }
+    .card-excerpt { font-size: 0.85rem; color: var(--text-3); line-height: 1.55; flex: 1; margin-bottom: 16px; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+    .card-meta { font-size: 0.75rem; color: var(--text-3); padding-top: 12px; border-top: 1px solid var(--border); display: flex; justify-content: space-between; }
+    .no-posts { grid-column: 1/-1; text-align: center; padding: 60px 20px; color: var(--text-3); }
+
+    @media (max-width: 700px) { .posts-grid { grid-template-columns: 1fr; } }
+
+    .app-banner {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: var(--radius-lg); padding: 28px 32px;
+      display: flex; align-items: center; gap: 20px; margin-bottom: 48px;
+    }
+    .app-banner-text { flex: 1; }
+    .app-banner-text p { margin: 0 0 12px; font-size: 0.92rem; color: var(--text-2); line-height: 1.5; }
+    .app-banner-text a { display: inline-block; padding: 9px 20px; background: var(--accent); color: var(--bg); font-weight: 700; font-size: 0.85rem; border-radius: 8px; text-decoration: none; }
+    .app-banner-text a:hover { opacity: 0.85; }
+    .app-banner-icon { font-size: 1.2rem; font-weight: 800; color: var(--accent); flex-shrink: 0; }
+    @media (max-width: 480px) { .app-banner { flex-direction: column; text-align: center; } }
+
+    .newsletter {
+      text-align: center; padding: 48px 32px; background: var(--surface);
+      border: 1px solid var(--border); border-radius: var(--radius-lg); margin-bottom: 64px;
+    }
+    .newsletter h2 { font-size: 1.4rem; margin-bottom: 8px; font-weight: 700; }
+    .newsletter p { color: var(--text-3); margin-bottom: 24px; font-size: 0.92rem; max-width: 420px; margin-left: auto; margin-right: auto; line-height: 1.5; }
+    .nl-form { display: flex; gap: 8px; max-width: 400px; margin: 0 auto 12px; }
+    .nl-form input { flex: 1; padding: 12px 16px; background: var(--bg); border: 1px solid var(--border); border-radius: 8px; color: var(--text); font-size: 0.88rem; font-family: inherit; }
+    .nl-form input::placeholder { color: var(--text-3); }
+    .nl-form input:focus { outline: none; border-color: var(--accent); }
+    .nl-form button { padding: 12px 24px; background: var(--accent); color: var(--bg); border: none; border-radius: 8px; font-weight: 700; font-size: 0.85rem; cursor: pointer; font-family: inherit; white-space: nowrap; }
+    .nl-form button:hover { opacity: 0.85; }
+    .nl-msg { font-size: 0.82rem; color: var(--accent); min-height: 1.2em; }
+    @media (max-width: 480px) { .nl-form { flex-direction: column; } }
+
+    footer { text-align: center; padding: 32px 24px; border-top: 1px solid var(--border); color: var(--text-3); font-size: 0.78rem; }
+    footer a { color: var(--text-3); }
+    footer a:hover { color: var(--text); }
+  </style>
+</head>
+<body>
+
+  <nav>
+    <a href="/" class="nav-brand">SleepMedic</a>
+    <div class="nav-links">
+      <a href="/blog/">Blog</a>
+      <a href="/blog/feed.xml">RSS</a>
+      <button type="button" class="nav-cta" data-app-interest="nurses-nav">Download App</button>
+    </div>
+  </nav>
+
+  <div class="page">
+
+    <div class="hero">
+      <h1>Sleep for Nurses</h1>
+      <p>12-hour shifts, night rotations, adrenaline that won't quit. Sleep protocols designed around what healthcare actually demands of your body.</p>
+    </div>
+
+    <a href="/blog/posts/shift-worker-sleep-protocol.html" class="pillar-card">
+      <div class="pillar-label">Complete Guide</div>
+      <h2>The Shift Worker Sleep Protocol</h2>
+      <p>The full evidence-based protocol for rotating and night shift workers: light management, circadian anchoring, post-shift wind-down, and rotation recovery.</p>
+    </a>
+
+    <div class="posts-grid" id="posts-grid">
+      <div class="no-posts">Loading articles...</div>
+    </div>
+
+    <div class="app-banner">
+      <div class="app-banner-icon">SM</div>
+      <div class="app-banner-text">
+        <p>SleepMedic is built for healthcare schedules -- 3-on-4-off, night rotations, float pools. Log sleep around your shifts, track fatigue patterns, and see how your schedule affects your recovery.</p>
+        <a href="#" data-app-interest="category-nurses">Download App</a>
+      </div>
+    </div>
+
+    <div class="newsletter">
+      <h2>Weekly sleep science for healthcare workers</h2>
+      <p>One email a week. Evidence-based sleep advice from someone who understands shift work biology.</p>
+      <form data-sm-newsletter data-sm-lead-magnet="shift-worker-toolkit">
+        <div class="nl-form">
+          <input type="email" name="email" required placeholder="you@email.com" />
+          <button type="submit">Subscribe</button>
+        </div>
+      </form>
+      <div class="nl-msg" data-sm-newsletter-msg></div>
+    </div>
+
+  </div>
+
+  <footer>
+    <p>&copy; 2026 TeachMeToLive LLC. All rights reserved.</p>
+    <p style="margin-top:6px;">
+      <a href="/">Home</a> &middot; <a href="/blog/">Blog</a> &middot; <a href="/blog/feed.xml">RSS</a> &middot; <a href="#" data-app-interest="nurses-footer">Download App</a>
+    </p>
+  </footer>
+
+  <script src="/assets/app-interest.js" data-pi="https://pi.sleepmedic.co/app-interest"></script>
+
+  <script>
+    async function loadPosts() {
+      try {
+        const res = await fetch('../posts-index.json');
+        const posts = await res.json();
+        const filtered = posts.filter(p => p.audience === 'nurses' && !p.pillar);
+        const grid = document.getElementById('posts-grid');
+        if (!filtered.length) {
+          grid.innerHTML = '<div class="no-posts"><p>Nurse-specific articles coming soon. The shift worker guides above apply directly to your schedule.</p></div>';
+          return;
+        }
+        grid.innerHTML = filtered.map(post => {
+          const img = post.coverImage
+            ? `<div class="card-img" style="background-image:url('../${post.coverImage}')"></div>`
+            : '';
+          return `
+            <a href="../posts/${post.slug}.html" class="card">
+              ${img}
+              <div class="card-body">
+                <div class="card-cat">${post.categoryLabel}</div>
+                <h3>${post.title}</h3>
+                <p class="card-excerpt">${post.excerpt}</p>
+                <div class="card-meta">
+                  <span>${post.dateFormatted}</span>
+                  <span>${post.readTime} min read</span>
+                </div>
+              </div>
+            </a>
+          `;
+        }).join('');
+      } catch {
+        document.getElementById('posts-grid').innerHTML = '<div class="no-posts"><p>Could not load articles.</p></div>';
+      }
+    }
+
+    (function() {
+      const f = document.querySelector('[data-sm-newsletter]');
+      const msg = document.querySelector('[data-sm-newsletter-msg]');
+      if (!f) return;
+      f.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const input = f.querySelector('input[name="email"]');
+        const email = (input?.value || '').trim();
+        if (!email) return;
+        msg.textContent = 'Subscribing...';
+        try {
+          const r = await fetch('https://pi.sleepmedic.co/subscribe', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email, leadMagnet: f.dataset.smLeadMagnet })
+          });
+          const d = await r.json();
+          if (d.ok) {
+            msg.textContent = d.already ? 'Already subscribed.' : 'Subscribed. Check your inbox.';
+            input.value = '';
+            if (window.gtag) window.gtag('event', 'newsletter_subscribe', { source: 'nurses' });
+          } else {
+            msg.textContent = d.error || 'Subscription failed.';
+          }
+        } catch {
+          msg.textContent = 'Network error. Try again.';
+        }
+      });
+    })();
+
+    loadPosts();
+  </script>
+</body>
+</html>

--- a/blog/paramedics/index.html
+++ b/blog/paramedics/index.html
@@ -1,0 +1,271 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sleep for Paramedics and EMTs - Fatigue and Shift Science | SleepMedic</title>
+  <meta name="description" content="Sleep and fatigue science for paramedics and EMTs. Managing 24-hour shifts, post-call recovery, hypervigilance wind-down, and circadian disruption on unpredictable schedules." />
+
+  <link rel="canonical" href="https://sleepmedic.co/blog/paramedics/" />
+  <meta name="robots" content="index,follow" />
+  <meta property="og:title" content="Sleep for Paramedics and EMTs | SleepMedic" />
+  <meta property="og:description" content="Sleep and fatigue science for paramedics and EMTs: 24-hour shifts, post-call recovery, hypervigilance wind-down, and circadian protocols." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://sleepmedic.co/blog/paramedics/" />
+  <meta property="og:site_name" content="SleepMedic" />
+
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
+  <link rel="alternate" type="application/rss+xml" title="SleepMedic Blog" href="https://sleepmedic.co/blog/feed.xml" />
+
+  <!-- Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "name": "Sleep for Paramedics and EMTs",
+    "description": "Sleep and fatigue science for paramedics and EMTs on 24-hour shifts: post-call recovery, hypervigilance wind-down, and circadian protocols for unpredictable schedules.",
+    "url": "https://sleepmedic.co/blog/paramedics/",
+    "publisher": {
+      "@type": "Organization",
+      "name": "SleepMedic",
+      "url": "https://sleepmedic.co",
+      "logo": { "@type": "ImageObject", "url": "https://sleepmedic.co/favicon-32.png" }
+    }
+  }
+  </script>
+
+  <!-- GA4 -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-717M9L2RTM"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-717M9L2RTM');
+  </script>
+
+  <!-- GoatCounter -->
+  <script data-goatcounter="https://jschwartz9.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="../_shared-styles.css">
+
+  <style>
+    .page { max-width: 1080px; margin: 0 auto; padding: 0 24px; }
+
+    nav {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 18px 24px; max-width: 1080px; margin: 0 auto;
+      border-bottom: 1px solid var(--border);
+    }
+    .nav-brand { font-size: 1rem; font-weight: 700; color: var(--text); letter-spacing: -0.02em; }
+    .nav-links { display: flex; gap: 20px; align-items: center; }
+    .nav-links a { font-size: 0.85rem; color: var(--text-3); font-weight: 500; transition: color 0.2s; }
+    .nav-links a:hover { color: var(--text); }
+    .nav-cta { padding: 7px 14px; background: rgba(167,139,250,0.10); border: 1px solid rgba(167,139,250,0.25); border-radius: 8px; color: var(--accent) !important; font-size: 0.8rem !important; font-weight: 600 !important; cursor: pointer; font-family: inherit; }
+    .nav-cta:hover { background: rgba(167,139,250,0.18); color: var(--text) !important; }
+
+    .hero { padding: 72px 0 40px; text-align: center; margin-bottom: 40px; }
+    .hero h1 {
+      font-size: clamp(2.2rem, 4.5vw, 3.2rem); font-weight: 800; letter-spacing: -0.03em;
+      margin-bottom: 16px;
+      background: linear-gradient(135deg, #fff 30%, var(--accent) 70%, var(--accent-2));
+      -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
+      line-height: 1.1;
+    }
+    .hero p { font-size: 1.05rem; color: var(--text-3); max-width: 520px; margin: 0 auto; line-height: 1.6; }
+
+    .pillar-card {
+      background: var(--surface); border: 1px solid var(--accent);
+      border-radius: var(--radius-lg); padding: 32px 36px;
+      margin-bottom: 40px; text-decoration: none; color: inherit;
+      transition: border-color 0.2s, transform 0.15s; display: block;
+    }
+    .pillar-card:hover { border-color: var(--accent-2); transform: translateY(-2px); }
+    .pillar-label { font-size: 0.68rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--accent-2); margin-bottom: 10px; }
+    .pillar-card h2 { font-size: 1.5rem; font-weight: 700; line-height: 1.3; margin-bottom: 10px; letter-spacing: -0.02em; }
+    .pillar-card p { font-size: 0.9rem; color: var(--text-3); line-height: 1.6; margin: 0; }
+
+    .posts-grid {
+      display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+      gap: 20px; margin-bottom: 48px;
+    }
+    .card {
+      display: flex; flex-direction: column; background: var(--surface);
+      border: 1px solid var(--border); border-radius: var(--radius-lg); overflow: hidden;
+      transition: border-color 0.2s, transform 0.15s; text-decoration: none; color: inherit;
+    }
+    .card:hover { border-color: var(--border-hover); transform: translateY(-3px); }
+    .card-img { width: 100%; height: 190px; background-size: cover; background-position: center; background-color: var(--surface-2); }
+    .card-body { padding: 22px; flex: 1; display: flex; flex-direction: column; }
+    .card-cat { font-size: 0.68rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 10px; color: var(--accent); }
+    .card-body h3 { font-size: 1.05rem; font-weight: 600; line-height: 1.4; margin-bottom: 8px; letter-spacing: -0.01em; }
+    .card-excerpt { font-size: 0.85rem; color: var(--text-3); line-height: 1.55; flex: 1; margin-bottom: 16px; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+    .card-meta { font-size: 0.75rem; color: var(--text-3); padding-top: 12px; border-top: 1px solid var(--border); display: flex; justify-content: space-between; }
+    .no-posts { grid-column: 1/-1; text-align: center; padding: 60px 20px; color: var(--text-3); }
+
+    @media (max-width: 700px) { .posts-grid { grid-template-columns: 1fr; } }
+
+    .app-banner {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: var(--radius-lg); padding: 28px 32px;
+      display: flex; align-items: center; gap: 20px; margin-bottom: 48px;
+    }
+    .app-banner-text { flex: 1; }
+    .app-banner-text p { margin: 0 0 12px; font-size: 0.92rem; color: var(--text-2); line-height: 1.5; }
+    .app-banner-text a { display: inline-block; padding: 9px 20px; background: var(--accent); color: var(--bg); font-weight: 700; font-size: 0.85rem; border-radius: 8px; text-decoration: none; }
+    .app-banner-text a:hover { opacity: 0.85; }
+    .app-banner-icon { font-size: 1.2rem; font-weight: 800; color: var(--accent); flex-shrink: 0; }
+    @media (max-width: 480px) { .app-banner { flex-direction: column; text-align: center; } }
+
+    .newsletter {
+      text-align: center; padding: 48px 32px; background: var(--surface);
+      border: 1px solid var(--border); border-radius: var(--radius-lg); margin-bottom: 64px;
+    }
+    .newsletter h2 { font-size: 1.4rem; margin-bottom: 8px; font-weight: 700; }
+    .newsletter p { color: var(--text-3); margin-bottom: 24px; font-size: 0.92rem; max-width: 420px; margin-left: auto; margin-right: auto; line-height: 1.5; }
+    .nl-form { display: flex; gap: 8px; max-width: 400px; margin: 0 auto 12px; }
+    .nl-form input { flex: 1; padding: 12px 16px; background: var(--bg); border: 1px solid var(--border); border-radius: 8px; color: var(--text); font-size: 0.88rem; font-family: inherit; }
+    .nl-form input::placeholder { color: var(--text-3); }
+    .nl-form input:focus { outline: none; border-color: var(--accent); }
+    .nl-form button { padding: 12px 24px; background: var(--accent); color: var(--bg); border: none; border-radius: 8px; font-weight: 700; font-size: 0.85rem; cursor: pointer; font-family: inherit; white-space: nowrap; }
+    .nl-form button:hover { opacity: 0.85; }
+    .nl-msg { font-size: 0.82rem; color: var(--accent); min-height: 1.2em; }
+    @media (max-width: 480px) { .nl-form { flex-direction: column; } }
+
+    footer { text-align: center; padding: 32px 24px; border-top: 1px solid var(--border); color: var(--text-3); font-size: 0.78rem; }
+    footer a { color: var(--text-3); }
+    footer a:hover { color: var(--text); }
+  </style>
+</head>
+<body>
+
+  <nav>
+    <a href="/" class="nav-brand">SleepMedic</a>
+    <div class="nav-links">
+      <a href="/blog/">Blog</a>
+      <a href="/blog/feed.xml">RSS</a>
+      <button type="button" class="nav-cta" data-app-interest="paramedics-nav">Download App</button>
+    </div>
+  </nav>
+
+  <div class="page">
+
+    <div class="hero">
+      <h1>Sleep for Paramedics and EMTs</h1>
+      <p>24-hour shifts, unpredictable call volume, post-adrenaline insomnia. Sleep science written for the specific demands of emergency medical work.</p>
+    </div>
+
+    <a href="/blog/posts/shift-worker-sleep-protocol.html" class="pillar-card">
+      <div class="pillar-label">Complete Guide</div>
+      <h2>The Shift Worker Sleep Protocol</h2>
+      <p>The full evidence-based protocol: post-shift wind-down, circadian anchoring between 24s, strategic napping on shift, and long-rotation recovery.</p>
+    </a>
+
+    <div class="posts-grid" id="posts-grid">
+      <div class="no-posts">Loading articles...</div>
+    </div>
+
+    <div class="app-banner">
+      <div class="app-banner-icon">SM</div>
+      <div class="app-banner-text">
+        <p>SleepMedic understands 24-hour shifts and unpredictable schedules. Log sleep around your call schedule, track fatigue debt across rotations, and see which recovery habits actually move the needle.</p>
+        <a href="#" data-app-interest="category-paramedics">Download App</a>
+      </div>
+    </div>
+
+    <div class="newsletter">
+      <h2>Weekly sleep science for EMS</h2>
+      <p>One email a week. Practical sleep and fatigue science for people who can't just go to bed at 10pm.</p>
+      <form data-sm-newsletter data-sm-lead-magnet="shift-worker-toolkit">
+        <div class="nl-form">
+          <input type="email" name="email" required placeholder="you@email.com" />
+          <button type="submit">Subscribe</button>
+        </div>
+      </form>
+      <div class="nl-msg" data-sm-newsletter-msg></div>
+    </div>
+
+  </div>
+
+  <footer>
+    <p>&copy; 2026 TeachMeToLive LLC. All rights reserved.</p>
+    <p style="margin-top:6px;">
+      <a href="/">Home</a> &middot; <a href="/blog/">Blog</a> &middot; <a href="/blog/feed.xml">RSS</a> &middot; <a href="#" data-app-interest="paramedics-footer">Download App</a>
+    </p>
+  </footer>
+
+  <script src="/assets/app-interest.js" data-pi="https://pi.sleepmedic.co/app-interest"></script>
+
+  <script>
+    async function loadPosts() {
+      try {
+        const res = await fetch('../posts-index.json');
+        const posts = await res.json();
+        const filtered = posts.filter(p => p.audience === 'paramedics' && !p.pillar);
+        const grid = document.getElementById('posts-grid');
+        if (!filtered.length) {
+          grid.innerHTML = '<div class="no-posts"><p>EMS-specific articles coming soon. The shift worker guides above are directly applicable to your schedule.</p></div>';
+          return;
+        }
+        grid.innerHTML = filtered.map(post => {
+          const img = post.coverImage
+            ? `<div class="card-img" style="background-image:url('../${post.coverImage}')"></div>`
+            : '';
+          return `
+            <a href="../posts/${post.slug}.html" class="card">
+              ${img}
+              <div class="card-body">
+                <div class="card-cat">${post.categoryLabel}</div>
+                <h3>${post.title}</h3>
+                <p class="card-excerpt">${post.excerpt}</p>
+                <div class="card-meta">
+                  <span>${post.dateFormatted}</span>
+                  <span>${post.readTime} min read</span>
+                </div>
+              </div>
+            </a>
+          `;
+        }).join('');
+      } catch {
+        document.getElementById('posts-grid').innerHTML = '<div class="no-posts"><p>Could not load articles.</p></div>';
+      }
+    }
+
+    (function() {
+      const f = document.querySelector('[data-sm-newsletter]');
+      const msg = document.querySelector('[data-sm-newsletter-msg]');
+      if (!f) return;
+      f.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const input = f.querySelector('input[name="email"]');
+        const email = (input?.value || '').trim();
+        if (!email) return;
+        msg.textContent = 'Subscribing...';
+        try {
+          const r = await fetch('https://pi.sleepmedic.co/subscribe', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email, leadMagnet: f.dataset.smLeadMagnet })
+          });
+          const d = await r.json();
+          if (d.ok) {
+            msg.textContent = d.already ? 'Already subscribed.' : 'Subscribed. Check your inbox.';
+            input.value = '';
+            if (window.gtag) window.gtag('event', 'newsletter_subscribe', { source: 'paramedics' });
+          } else {
+            msg.textContent = d.error || 'Subscription failed.';
+          }
+        } catch {
+          msg.textContent = 'Network error. Try again.';
+        }
+      });
+    })();
+
+    loadPosts();
+  </script>
+</body>
+</html>

--- a/blog/posts-index.json
+++ b/blog/posts-index.json
@@ -1,5 +1,18 @@
 [
   {
+    "title": "The Shift Worker Sleep Protocol: A Complete Evidence-Based Guide",
+    "slug": "shift-worker-sleep-protocol",
+    "excerpt": "A full protocol for shift workers to protect sleep, manage circadian disruption, and recover faster between rotations.",
+    "date": "2026-04-16",
+    "dateFormatted": "April 16, 2026",
+    "readTime": 12,
+    "category": "special",
+    "categoryLabel": "Shift Work",
+    "coverImage": null,
+    "pillar": true,
+    "audience": "shift-workers"
+  },
+  {
     "title": "Why the 90-Minute Sleep Cycle Myth Leaves You Tired",
     "slug": "2026-04-14-why-the-90-minute-sleep-cycle-myth-leaves-you-tired",
     "excerpt": "That popular 'sleep hack' often fails because your sleep cycles are unique. Discover the real science behind truly refreshing rest.",
@@ -85,7 +98,8 @@
     "readTime": 3,
     "category": "timing",
     "categoryLabel": "Timing",
-    "coverImage": "posts/images/2026-02-02-what-time-should-i-sleep-and-wake-cover.jpg"
+    "coverImage": "posts/images/2026-02-02-what-time-should-i-sleep-and-wake-cover.jpg",
+    "audience": "shift-workers"
   },
   {
     "title": "Box Breathing and 4-7-8 Technique for Better Sleep",
@@ -118,7 +132,8 @@
     "readTime": 3,
     "category": "special",
     "categoryLabel": "Special",
-    "coverImage": "posts/images/2026-01-12-protecting-sleep-as-a-shift-worker-evidence-based-tactics-cover.jpg"
+    "coverImage": "posts/images/2026-01-12-protecting-sleep-as-a-shift-worker-evidence-based-tactics-cover.jpg",
+    "audience": "shift-workers"
   },
   {
     "title": "Nighttime Habits That Help Sleep for Shift Workers",
@@ -129,7 +144,8 @@
     "readTime": 3,
     "category": "tools",
     "categoryLabel": "Tools",
-    "coverImage": "posts/images/2025-12-29-nighttime-habits-that-help-sleep-for-shift-workers-cover.jpg"
+    "coverImage": "posts/images/2025-12-29-nighttime-habits-that-help-sleep-for-shift-workers-cover.jpg",
+    "audience": "shift-workers"
   },
   {
     "title": "Long-Term Effects of Poor Sleep: What Shift Workers Need to Know",
@@ -140,7 +156,8 @@
     "readTime": 2,
     "category": "science",
     "categoryLabel": "Science",
-    "coverImage": "posts/images/2025-12-22-long-term-effects-of-poor-sleep-what-shift-workers-need-to-know-cover.jpg"
+    "coverImage": "posts/images/2025-12-22-long-term-effects-of-poor-sleep-what-shift-workers-need-to-know-cover.jpg",
+    "audience": "shift-workers"
   },
   {
     "title": "Adjust Your Schedule Without Chaos: A Shift Work Guide",
@@ -151,7 +168,8 @@
     "readTime": 3,
     "category": "special",
     "categoryLabel": "Special",
-    "coverImage": "posts/images/2025-12-15-adjust-your-schedule-without-chaos-a-shift-work-guide-cover.jpg"
+    "coverImage": "posts/images/2025-12-15-adjust-your-schedule-without-chaos-a-shift-work-guide-cover.jpg",
+    "audience": "shift-workers"
   },
   {
     "title": "Myth-Busting Sleep for Shift Workers: What You Need to Know",
@@ -162,7 +180,8 @@
     "readTime": 3,
     "category": "timing",
     "categoryLabel": "Timing",
-    "coverImage": "posts/images/2025-12-10-myth-busting-sleep-for-shift-workers-what-you-need-to-know-cover.jpg"
+    "coverImage": "posts/images/2025-12-10-myth-busting-sleep-for-shift-workers-what-you-need-to-know-cover.jpg",
+    "audience": "shift-workers"
   },
   {
     "title": "Cultural Sleep Practices You Can Use for Better Rest",
@@ -195,6 +214,7 @@
     "readTime": 5,
     "category": "science",
     "categoryLabel": "Science",
-    "coverImage": "posts/images/2025-07-10-shift-workers-wake-up-consistency-cover.jpg"
+    "coverImage": "posts/images/2025-07-10-shift-workers-wake-up-consistency-cover.jpg",
+    "audience": "shift-workers"
   }
 ]

--- a/blog/shift-workers/index.html
+++ b/blog/shift-workers/index.html
@@ -1,0 +1,276 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sleep for Shift Workers - Evidence-Based Guides | SleepMedic</title>
+  <meta name="description" content="Sleep science and protocols built specifically for shift workers. Circadian management, rotation recovery, and sleep protection for night and rotating shifts." />
+
+  <link rel="canonical" href="https://sleepmedic.co/blog/shift-workers/" />
+  <meta name="robots" content="index,follow" />
+  <meta property="og:title" content="Sleep for Shift Workers | SleepMedic" />
+  <meta property="og:description" content="Evidence-based sleep protocols for shift workers, night shift nurses, EMTs, firefighters, and anyone working outside 9-5." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://sleepmedic.co/blog/shift-workers/" />
+  <meta property="og:site_name" content="SleepMedic" />
+
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
+  <link rel="alternate" type="application/rss+xml" title="SleepMedic Blog" href="https://sleepmedic.co/blog/feed.xml" />
+
+  <!-- Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "name": "Sleep for Shift Workers",
+    "description": "Evidence-based sleep science and protocols for shift workers, night shift nurses, EMTs, firefighters, and rotating schedule workers.",
+    "url": "https://sleepmedic.co/blog/shift-workers/",
+    "publisher": {
+      "@type": "Organization",
+      "name": "SleepMedic",
+      "url": "https://sleepmedic.co",
+      "logo": { "@type": "ImageObject", "url": "https://sleepmedic.co/favicon-32.png" }
+    }
+  }
+  </script>
+
+  <!-- GA4 -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-717M9L2RTM"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-717M9L2RTM');
+  </script>
+
+  <!-- GoatCounter -->
+  <script data-goatcounter="https://jschwartz9.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="../_shared-styles.css">
+
+  <style>
+    .page { max-width: 1080px; margin: 0 auto; padding: 0 24px; }
+
+    nav {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 18px 24px; max-width: 1080px; margin: 0 auto;
+      border-bottom: 1px solid var(--border);
+    }
+    .nav-brand { font-size: 1rem; font-weight: 700; color: var(--text); letter-spacing: -0.02em; }
+    .nav-links { display: flex; gap: 20px; align-items: center; }
+    .nav-links a { font-size: 0.85rem; color: var(--text-3); font-weight: 500; transition: color 0.2s; }
+    .nav-links a:hover { color: var(--text); }
+    .nav-cta { padding: 7px 14px; background: rgba(167,139,250,0.10); border: 1px solid rgba(167,139,250,0.25); border-radius: 8px; color: var(--accent) !important; font-size: 0.8rem !important; font-weight: 600 !important; cursor: pointer; font-family: inherit; }
+    .nav-cta:hover { background: rgba(167,139,250,0.18); color: var(--text) !important; }
+
+    .hero { padding: 72px 0 40px; text-align: center; margin-bottom: 40px; }
+    .hero h1 {
+      font-size: clamp(2.2rem, 4.5vw, 3.2rem); font-weight: 800; letter-spacing: -0.03em;
+      margin-bottom: 16px;
+      background: linear-gradient(135deg, #fff 30%, var(--accent) 70%, var(--accent-2));
+      -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
+      line-height: 1.1;
+    }
+    .hero p { font-size: 1.05rem; color: var(--text-3); max-width: 520px; margin: 0 auto; line-height: 1.6; }
+
+    .pillar-card {
+      display: grid; grid-template-columns: 1fr; gap: 0;
+      background: var(--surface); border: 1px solid var(--accent);
+      border-radius: var(--radius-lg); padding: 32px 36px;
+      margin-bottom: 40px; text-decoration: none; color: inherit;
+      transition: border-color 0.2s, transform 0.15s;
+    }
+    .pillar-card:hover { border-color: var(--accent-2); transform: translateY(-2px); }
+    .pillar-label { font-size: 0.68rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--accent-2); margin-bottom: 10px; }
+    .pillar-card h2 { font-size: 1.5rem; font-weight: 700; line-height: 1.3; margin-bottom: 10px; letter-spacing: -0.02em; }
+    .pillar-card p { font-size: 0.9rem; color: var(--text-3); line-height: 1.6; margin: 0; }
+
+    .posts-grid {
+      display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+      gap: 20px; margin-bottom: 48px;
+    }
+    .card {
+      display: flex; flex-direction: column; background: var(--surface);
+      border: 1px solid var(--border); border-radius: var(--radius-lg); overflow: hidden;
+      transition: border-color 0.2s, transform 0.15s; text-decoration: none; color: inherit;
+    }
+    .card:hover { border-color: var(--border-hover); transform: translateY(-3px); }
+    .card-img { width: 100%; height: 190px; background-size: cover; background-position: center; background-color: var(--surface-2); }
+    .card-body { padding: 22px; flex: 1; display: flex; flex-direction: column; }
+    .card-cat { font-size: 0.68rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 10px; color: var(--accent); }
+    .card-body h3 { font-size: 1.05rem; font-weight: 600; line-height: 1.4; margin-bottom: 8px; letter-spacing: -0.01em; }
+    .card-excerpt { font-size: 0.85rem; color: var(--text-3); line-height: 1.55; flex: 1; margin-bottom: 16px; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+    .card-meta { font-size: 0.75rem; color: var(--text-3); padding-top: 12px; border-top: 1px solid var(--border); display: flex; justify-content: space-between; }
+    .no-posts { grid-column: 1/-1; text-align: center; padding: 60px 20px; color: var(--text-3); }
+
+    @media (max-width: 700px) { .posts-grid { grid-template-columns: 1fr; } }
+
+    .app-banner {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: var(--radius-lg); padding: 28px 32px;
+      display: flex; align-items: center; gap: 20px; margin-bottom: 48px;
+    }
+    .app-banner-text { flex: 1; }
+    .app-banner-text p { margin: 0 0 12px; font-size: 0.92rem; color: var(--text-2); line-height: 1.5; }
+    .app-banner-text a {
+      display: inline-block; padding: 9px 20px; background: var(--accent);
+      color: var(--bg); font-weight: 700; font-size: 0.85rem; border-radius: 8px; text-decoration: none;
+    }
+    .app-banner-text a:hover { opacity: 0.85; }
+    .app-banner-icon { font-size: 1.2rem; font-weight: 800; color: var(--accent); flex-shrink: 0; }
+    @media (max-width: 480px) { .app-banner { flex-direction: column; text-align: center; } }
+
+    .newsletter {
+      text-align: center; padding: 48px 32px; background: var(--surface);
+      border: 1px solid var(--border); border-radius: var(--radius-lg); margin-bottom: 64px;
+    }
+    .newsletter h2 { font-size: 1.4rem; margin-bottom: 8px; font-weight: 700; }
+    .newsletter p { color: var(--text-3); margin-bottom: 24px; font-size: 0.92rem; max-width: 420px; margin-left: auto; margin-right: auto; line-height: 1.5; }
+    .nl-form { display: flex; gap: 8px; max-width: 400px; margin: 0 auto 12px; }
+    .nl-form input { flex: 1; padding: 12px 16px; background: var(--bg); border: 1px solid var(--border); border-radius: 8px; color: var(--text); font-size: 0.88rem; font-family: inherit; }
+    .nl-form input::placeholder { color: var(--text-3); }
+    .nl-form input:focus { outline: none; border-color: var(--accent); }
+    .nl-form button { padding: 12px 24px; background: var(--accent); color: var(--bg); border: none; border-radius: 8px; font-weight: 700; font-size: 0.85rem; cursor: pointer; font-family: inherit; white-space: nowrap; }
+    .nl-form button:hover { opacity: 0.85; }
+    .nl-msg { font-size: 0.82rem; color: var(--accent); min-height: 1.2em; }
+    @media (max-width: 480px) { .nl-form { flex-direction: column; } }
+
+    footer { text-align: center; padding: 32px 24px; border-top: 1px solid var(--border); color: var(--text-3); font-size: 0.78rem; }
+    footer a { color: var(--text-3); }
+    footer a:hover { color: var(--text); }
+  </style>
+</head>
+<body>
+
+  <nav>
+    <a href="/" class="nav-brand">SleepMedic</a>
+    <div class="nav-links">
+      <a href="/blog/">Blog</a>
+      <a href="/blog/feed.xml">RSS</a>
+      <button type="button" class="nav-cta" data-app-interest="shift-workers-nav">Download App</button>
+    </div>
+  </nav>
+
+  <div class="page">
+
+    <div class="hero">
+      <h1>Sleep for Shift Workers</h1>
+      <p>Night shifts, rotating schedules, 12-hour runs. Real protocols for protecting your sleep when the clock works against you.</p>
+    </div>
+
+    <a href="/blog/posts/shift-worker-sleep-protocol.html" class="pillar-card">
+      <div class="pillar-label">Complete Guide</div>
+      <h2>The Shift Worker Sleep Protocol</h2>
+      <p>Everything in one place: circadian anchoring, light timing, nap strategy, and rotation recovery. The full evidence-based protocol for shift workers.</p>
+    </a>
+
+    <div class="posts-grid" id="posts-grid">
+      <div class="no-posts">Loading articles...</div>
+    </div>
+
+    <div class="app-banner">
+      <div class="app-banner-icon">SM</div>
+      <div class="app-banner-text">
+        <p>SleepMedic adapts to your actual shift schedule -- not a rigid 9-5 ideal. Get reminders timed to your rotation, track sleep consistency, and see what's actually working.</p>
+        <a href="#" data-app-interest="category-shift-workers">Download App</a>
+      </div>
+    </div>
+
+    <div class="newsletter">
+      <h2>Weekly sleep science for shift workers</h2>
+      <p>One email a week. Practical, evidence-based advice from someone who understands your schedule.</p>
+      <form data-sm-newsletter data-sm-lead-magnet="shift-worker-toolkit">
+        <div class="nl-form">
+          <input type="email" name="email" required placeholder="you@email.com" />
+          <button type="submit">Subscribe</button>
+        </div>
+      </form>
+      <div class="nl-msg" data-sm-newsletter-msg></div>
+    </div>
+
+  </div>
+
+  <footer>
+    <p>&copy; 2026 TeachMeToLive LLC. All rights reserved.</p>
+    <p style="margin-top:6px;">
+      <a href="/">Home</a> &middot; <a href="/blog/">Blog</a> &middot; <a href="/blog/feed.xml">RSS</a> &middot; <a href="#" data-app-interest="shift-workers-footer">Download App</a>
+    </p>
+  </footer>
+
+  <script src="/assets/app-interest.js" data-pi="https://pi.sleepmedic.co/app-interest"></script>
+
+  <script>
+    async function loadPosts() {
+      try {
+        const res = await fetch('../posts-index.json');
+        const posts = await res.json();
+        const filtered = posts.filter(p => p.audience === 'shift-workers' && !p.pillar);
+        const grid = document.getElementById('posts-grid');
+        if (!filtered.length) {
+          grid.innerHTML = '<div class="no-posts"><p>More articles coming soon.</p></div>';
+          return;
+        }
+        grid.innerHTML = filtered.map(post => {
+          const img = post.coverImage
+            ? `<div class="card-img" style="background-image:url('../${post.coverImage}')"></div>`
+            : '';
+          return `
+            <a href="../posts/${post.slug}.html" class="card">
+              ${img}
+              <div class="card-body">
+                <div class="card-cat">${post.categoryLabel}</div>
+                <h3>${post.title}</h3>
+                <p class="card-excerpt">${post.excerpt}</p>
+                <div class="card-meta">
+                  <span>${post.dateFormatted}</span>
+                  <span>${post.readTime} min read</span>
+                </div>
+              </div>
+            </a>
+          `;
+        }).join('');
+      } catch {
+        document.getElementById('posts-grid').innerHTML = '<div class="no-posts"><p>Could not load articles.</p></div>';
+      }
+    }
+
+    // Newsletter submit
+    (function() {
+      const f = document.querySelector('[data-sm-newsletter]');
+      const msg = document.querySelector('[data-sm-newsletter-msg]');
+      if (!f) return;
+      f.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const input = f.querySelector('input[name="email"]');
+        const email = (input?.value || '').trim();
+        if (!email) return;
+        msg.textContent = 'Subscribing...';
+        try {
+          const r = await fetch('https://pi.sleepmedic.co/subscribe', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email, leadMagnet: f.dataset.smLeadMagnet })
+          });
+          const d = await r.json();
+          if (d.ok) {
+            msg.textContent = d.already ? 'Already subscribed.' : 'Subscribed. Check your inbox.';
+            input.value = '';
+            if (window.gtag) window.gtag('event', 'newsletter_subscribe', { source: 'shift-workers' });
+          } else {
+            msg.textContent = d.error || 'Subscription failed.';
+          }
+        } catch {
+          msg.textContent = 'Network error. Try again.';
+        }
+      });
+    })();
+
+    loadPosts();
+  </script>
+</body>
+</html>

--- a/scripts/generate-blog-post.mjs
+++ b/scripts/generate-blog-post.mjs
@@ -424,8 +424,7 @@ This week's template format: ${format}`;
 
   const researchSummary = JSON.stringify(research, null, 2);
 
-  const outline = await gemini(
-    `Plan a blog post.
+  const planPrompt = `Plan a blog post.
 
 TOPIC: "${topicInfo.topic}"
 ANGLE: ${topicInfo.angle}
@@ -458,8 +457,10 @@ Return JSON:
     }
   ],
   "imagePrompt": "a visually distinct, editorial scene. Be creative and varied. Examples: misty mountain ridge at first light, neurons firing in a stylized brain cross-section, rain streaking down a kitchen window at dawn, a lone jogger on an empty bridge at blue hour, macro shot of an espresso surface, city skyline shifting from night to sunrise, a lab bench with a circadian rhythm chart, golden light filtering through forest canopy, hands wrapped around a thermos on a cold morning, neon pharmacy sign reflected in a rain puddle. Avoid: beds, bedrooms, pillows, generic sleeping scenes. Each post should look completely different.",
+  "cover_alt": "80-125 char descriptive alt text for cover image including primary keyword",
   "inline_image_after_section": 2,
   "inline_image_prompt": "a second editorial image tied to this section's content. Be visually creative -- nature, science, workplace, urban, or abstract. NOT a bedroom or bed.",
+  "inline_alt": "80-125 char descriptive alt text for inline image including primary keyword",
   "closingLine": "short grounded closing line"
 }
 
@@ -471,9 +472,30 @@ RULES:
 - Section headings: specific to THIS topic, never generic
 - inline_image_after_section: pick the section index where a visual would help most
 - Title must match what someone would search for. No clickbait.
-- If RELATED SEARCHES are provided, work at least 1-2 into section headings or content angles (these are real queries people type).`,
-    { system, json: true, temp: 0.7 }
-  );
+- cover_alt and inline_alt: descriptive, 80-125 chars, include the primary keyword phrase
+- If RELATED SEARCHES are provided, work at least 1-2 into section headings or content angles (these are real queries people type).`;
+
+  let outline = await gemini(planPrompt, { system, json: true, temp: 0.7 });
+
+  // Validate title contains at least one token from seo_angles or topic
+  const seoTokens = [
+    ...(research.seo_angles || []),
+    topicInfo.topic
+  ].flatMap(s => s.toLowerCase().split(/\s+/)).filter(t => t.length > 3);
+  const titleLower = (outline.title || '').toLowerCase();
+  const titleHasToken = seoTokens.some(t => titleLower.includes(t));
+
+  // Validate excerpt length (140-160 chars) and contains primary keyword
+  const primaryKw = (topicInfo.search_query || topicInfo.topic).toLowerCase().split(/\s+/).slice(0, 3).join(' ');
+  const excerptLen = (outline.excerpt || '').length;
+  const excerptValid = excerptLen >= 140 && excerptLen <= 160 && (outline.excerpt || '').toLowerCase().includes(primaryKw.split(' ')[0]);
+
+  if (!titleHasToken || !excerptValid) {
+    if (!titleHasToken) logDetail(`Title missing SEO token, retrying stage 3...`);
+    if (!excerptValid) logDetail(`Excerpt length ${excerptLen} or missing keyword, retrying stage 3...`);
+    const retry = await gemini(planPrompt, { system, json: true, temp: 0.7 });
+    outline = retry;
+  }
 
   logDetail(`Title: "${outline.title}"`);
   logDetail(`Sections: ${outline.sections.length}`);
@@ -757,6 +779,22 @@ async function stage9_generateImages(outline, slug) {
 // STAGE 10: HTML BUILDER
 // ════════════════════════════════════════════════════════
 
+// ── Heading hierarchy lint ────────────────────────────
+function fixHeadingHierarchy(html) {
+  // Strip any <h1> in body content (template provides the page H1)
+  html = html.replace(/<h1([^>]*)>([\s\S]*?)<\/h1>/gi, '<h2$1>$2</h2>');
+  // Promote orphan <h3> that have no preceding <h2> in the same content
+  let hasH2 = false;
+  html = html.replace(/<(\/?)h([23])([^>]*)>/gi, (match, close, level, attrs) => {
+    if (level === '2') { if (!close) hasH2 = true; return match; }
+    if (level === '3') {
+      if (!hasH2) return `<${close}h2${attrs}>`;
+    }
+    return match;
+  });
+  return html;
+}
+
 async function stage10_buildHtml(content, topicInfo, outline, images) {
   log(10, 'Building HTML...');
 
@@ -764,14 +802,19 @@ async function stage10_buildHtml(content, topicInfo, outline, images) {
   const dateISO = dateISOmt();
   const dateFormatted = dateFormattedMT();
   const slug = `${dateISO}-${slugify(outline.title)}`;
+
+  // Heading hierarchy lint pass
+  content = fixHeadingHierarchy(content);
+
   const wordCount = content.replace(/<[^>]+>/g, '').split(/\s+/).filter(Boolean).length;
   const readTime = Math.ceil(wordCount / 200);
 
   // Insert inline image at the slot
   if (images.inlinePath) {
     const relPath = `images/${slug}-inline-1.jpg`;
+    const inlineAlt = outline.inline_alt || `Illustration for ${outline.title}`;
     const imgHtml = `<figure style="margin: 32px 0;">
-        <img src="${relPath}" alt="Illustration for ${outline.title}" style="width: 100%; border-radius: 16px; max-height: 360px; object-fit: cover;" loading="lazy">
+        <img src="${relPath}" alt="${inlineAlt}" style="width: 100%; border-radius: 16px; max-height: 360px; object-fit: cover;" loading="lazy">
       </figure>`;
     content = content.replace('<!-- INLINE_IMAGE_SLOT -->', imgHtml);
   } else {
@@ -799,10 +842,57 @@ async function stage10_buildHtml(content, topicInfo, outline, images) {
       html = html.replace(/(<meta property="og:url"[^>]*>)/, `$1\n${ogImageTag}`);
     }
 
+    const coverAlt = outline.cover_alt || `Cover image for ${outline.title}`;
     const coverHtml = `      <div style="margin-bottom: 40px;">
-        <img src="${imageRelPath}" alt="Cover image for ${outline.title}" style="width: 100%; max-height: 400px; object-fit: cover; border-radius: 24px;" loading="lazy">
+        <img src="${imageRelPath}" alt="${coverAlt}" style="width: 100%; max-height: 400px; object-fit: cover; border-radius: 24px;" loading="lazy">
       </div>\n`;
     html = html.replace('<div class="post-content">', coverHtml + '      <div class="post-content">');
+  }
+
+  // ── FAQ + HowTo schema injection ──────────────────────
+  const extraSchemas = [];
+
+  // FAQPage: Q&A template type OR 3+ h2s ending with ?
+  const faqH2s = [...html.matchAll(/<h2[^>]*>(.*?)<\/h2>/gi)].map(m => m[1].replace(/<[^>]+>/g, '').trim());
+  const questionH2s = faqH2s.filter(h => h.endsWith('?'));
+  if (outline.template_type === 'Q&A' || questionH2s.length >= 3) {
+    const mainEntity = questionH2s.map(q => {
+      // Extract text of paragraphs between this h2 and the next heading
+      const escaped = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const match = html.match(new RegExp(`<h2[^>]*>${escaped}<\\/h2>([\\s\\S]*?)(?=<h[23]|$)`, 'i'));
+      const answerText = match ? match[1].replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 500) : '';
+      return { '@type': 'Question', name: q, acceptedAnswer: { '@type': 'Answer', text: answerText } };
+    });
+    if (mainEntity.length >= 3) {
+      extraSchemas.push(JSON.stringify({ '@context': 'https://schema.org', '@type': 'FAQPage', mainEntity }, null, 2));
+      logDetail(`FAQPage schema: ${mainEntity.length} questions`);
+    }
+  }
+
+  // HowTo: Field Manual template type OR first <ol> with 3+ <li>
+  const olMatch = html.match(/<ol[^>]*>([\s\S]*?)<\/ol>/i);
+  if (outline.template_type === 'Field Manual' || olMatch) {
+    const olHtml = olMatch ? olMatch[1] : '';
+    const liItems = [...olHtml.matchAll(/<li[^>]*>([\s\S]*?)<\/li>/gi)].map(m => m[1].replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim());
+    if (liItems.length >= 3) {
+      const steps = liItems.map((text, i) => ({
+        '@type': 'HowToStep',
+        name: text.slice(0, 80),
+        text: text.slice(0, 300)
+      }));
+      extraSchemas.push(JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'HowTo',
+        name: outline.title,
+        step: steps
+      }, null, 2));
+      logDetail(`HowTo schema: ${steps.length} steps`);
+    }
+  }
+
+  if (extraSchemas.length) {
+    const injection = extraSchemas.map(s => `  <script type="application/ld+json">\n  ${s}\n  </script>`).join('\n');
+    html = html.replace('</head>', `${injection}\n</head>`);
   }
 
   const filename = `${slug}.html`;

--- a/scripts/generate-posts-index.mjs
+++ b/scripts/generate-posts-index.mjs
@@ -54,6 +54,16 @@ async function extractPostMetadata(filepath) {
 
 async function generatePostsIndex() {
   const postsDir = 'blog/posts';
+  const indexPath = 'blog/posts-index.json';
+
+  // Load existing index to preserve hand-edited fields (pillar, audience, etc.)
+  let existing = [];
+  try {
+    existing = JSON.parse(await fs.readFile(indexPath, 'utf8'));
+  } catch { /* fresh start */ }
+  // Build a lookup by slug for fast field preservation
+  const existingBySlug = Object.fromEntries(existing.map(p => [p.slug, p]));
+
   const files = await fs.readdir(postsDir);
   const htmlFiles = files.filter(f => f.endsWith('.html'));
 
@@ -62,13 +72,23 @@ async function generatePostsIndex() {
     const filepath = path.join(postsDir, file);
     const metadata = await extractPostMetadata(filepath);
     if (metadata) {
+      const prev = existingBySlug[metadata.slug] || {};
+      // Preserve pillar and audience if they were set
+      if (prev.pillar) metadata.pillar = prev.pillar;
+      if (prev.audience) metadata.audience = prev.audience;
       posts.push(metadata);
+    }
+  }
+
+  // Preserve entries that have no HTML file (e.g. the pillar post placeholder)
+  for (const entry of existing) {
+    if (!posts.find(p => p.slug === entry.slug)) {
+      posts.push(entry);
     }
   }
 
   posts.sort((a, b) => new Date(b.date) - new Date(a.date));
 
-  const indexPath = 'blog/posts-index.json';
   await fs.writeFile(indexPath, JSON.stringify(posts, null, 2));
 
   console.log(`Generated posts index with ${posts.length} posts`);

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -21,6 +21,12 @@
     <priority>0.3</priority>
   </url>
   <url>
+    <loc>https://sleepmedic.co/blog/posts/shift-worker-sleep-protocol.html</loc>
+    <lastmod>2026-04-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://sleepmedic.co/blog/posts/2026-04-14-why-the-90-minute-sleep-cycle-myth-leaves-you-tired.html</loc>
     <lastmod>2026-04-14</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
## Changes

- Add 4 lifecycle category pages (`/blog/shift-workers/`, `/blog/new-parents/`, `/blog/nurses/`, `/blog/paramedics/`) — each with CollectionPage JSON-LD, audience-filtered post grid, pillar post link, newsletter form, and app CTA
- Add `/about/` E-E-A-T author page with Person JSON-LD and complete credibility copy (paramedic background, editorial standards, who-this-is-for)
- Update `blog/_template.html`: byline link to `/about/` in post-meta; BlogPosting author changed from Organization to Person
- Update `blog/posts-index.json`: add pillar post entry for `shift-worker-sleep-protocol`; add `audience: "shift-workers"` on 8 posts
- Update `scripts/generate-posts-index.mjs`: preserve `pillar`/`audience` fields and pillar-placeholder entries across regenerations
- Update `scripts/generate-blog-post.mjs`:
  - Stage 3: validate title has SEO token from research angles; validate excerpt is 140-160 chars; retry once on failure
  - Stage 3 outline schema: add `cover_alt` and `inline_alt` fields (80-125 char descriptive alt text); thread through to stage 12
  - Post-HTML: heading hierarchy lint pass (demote body `<h1>` to `<h2>`, promote orphan `<h3>` to `<h2>`)
  - Stage 12: auto-inject FAQPage JSON-LD for Q&A posts with 3+ question h2s; HowTo JSON-LD for Field Manual / ordered-list posts
- Update README (10-stage → 12-stage), ANALYTICS (FAQ/HowTo SERP note), OPERATIONS (SEO runbook section)