### PR TITLE
Voice pass: strip AI filler, rewrite intros, add archetype system

### DIFF
--- a/blog/posts/2025-10-16-sleep-like-a-warrior.html
+++ b/blog/posts/2025-10-16-sleep-like-a-warrior.html
@@ -247,9 +247,7 @@
         <li>Get morning light within 30 minutes of waking — this anchors your circadian clock for the day</li>
       </ul>
 
-      <p>This approach isn't about imitating history. It's about recognizing that rest has always been a practice, not a passive state — and that the people who have performed under the most demanding conditions have understood this.</p>
-
-      <p>Your shift might be unpredictable. Your sleep environment might be imperfect. But your approach to rest? That's entirely within your control.</p>
+      <p>The through-line across all of these traditions is that rest was never treated as something that just happened when you were tired enough. It was approached — with preparation, ritual, and the understanding that recovery was as much a part of the work as the work itself. The people who performed under genuinely demanding conditions understood this not as philosophy but as operational necessity.</p>
 
       <p>For a complete protocol covering the science of shift worker sleep — light management, nap strategy, rotation recovery — see the <a href="/blog/posts/shift-worker-sleep-protocol.html">Shift Worker Sleep Protocol</a>.</p>
     </div>

--- a/blog/posts/2025-10-23-cultural-sleep-practices.html
+++ b/blog/posts/2025-10-23-cultural-sleep-practices.html
@@ -199,9 +199,9 @@
         <img src="images/2025-10-23-cultural-sleep-practices-cover.jpg" alt="Cover image" style="width: 100%; max-height: 400px; object-fit: cover; border-radius: 24px;">
         
       </div>
-      <h2>The Sleep Revolution: A Global Perspective</h2>
+      <h2>What other cultures figured out about sleep</h2>
 
-      <p>Imagine you're a night shift worker starting your day as others wind down. The world operates on a rhythm you're not part of — stores are open when you're sleeping, families are having dinner when you're starting your shift. Around the world, different cultures have developed sleep practices that work around social norms and biological constraints. Some of these translate directly to the shift worker's situation.</p>
+      <p>The dominant modern framework — one long block of sleep at night, stimulants to compensate when it fails — is actually the historical outlier. Most pre-industrial societies had a more nuanced relationship with sleep than we do. They napped strategically. They had rituals. They built environments and social structures that supported rest rather than fighting against it. Looking across those traditions, a few things are worth paying attention to, especially if your schedule already forces you to sleep outside the conventional window.</p>
 
       <p>What's striking when you look across cultures is that most pre-industrial societies had a more nuanced relationship with sleep than modern Western culture does. They napped strategically. They had rituals. They built environments that supported rest rather than fighting against it. The dominant modern framework — one long block of sleep at night, stimulants to compensate when it fails — is actually the historical outlier.</p>
 

--- a/blog/posts/2025-12-22-long-term-effects-of-poor-sleep-what-shift-workers-need-to-know.html
+++ b/blog/posts/2025-12-22-long-term-effects-of-poor-sleep-what-shift-workers-need-to-know.html
@@ -258,8 +258,8 @@
       </div>
 
       <div class="post-content">
-        <h2>Why Sleep Matters for Shift Workers</h2>
-<p>Imagine clocking out after a grueling 24-hour shift, only to find sleep elusive. For many shift workers, this is a daily reality, and it can have profound long-term effects on health. The research on chronic sleep deprivation isn't ambiguous: consistently sleeping less than 7 hours per night puts you at measurably higher risk for a range of serious conditions. For shift workers, who often struggle to hit that target even when they try, this isn't a theoretical risk — it's an occupational hazard.</p>
+        <h2>The long-term cost of short sleep</h2>
+<p>The research on chronic sleep deprivation isn't ambiguous: consistently sleeping fewer than 7 hours per night puts you at measurably higher risk for cardiovascular disease, metabolic dysfunction, cognitive decline, and several cancers. For shift workers — who often can't hit that target even when they try — this isn't a theoretical risk. It's an occupational hazard that accumulates across a career, quietly, without obvious day-to-day markers until the damage is already compounding.</p>
 
 <h2>What Happens When You Don't Sleep Well?</h2>
 <p>Chronic sleep deprivation can lead to serious health issues, including cardiovascular disease, obesity, and mental health disorders. According to the <a href="https://www.cdc.gov/sleep/index.html">CDC</a>, adults who consistently sleep less than 7 hours per night are at greater risk for these conditions. The effects compound over time: a week of poor sleep produces measurable cognitive impairment equivalent to two nights of total sleep deprivation, and that debt doesn't fully reverse with a single good night.</p>

--- a/blog/posts/2026-04-16-the-hardest-part-of-good-sleep.html
+++ b/blog/posts/2026-04-16-the-hardest-part-of-good-sleep.html
@@ -246,57 +246,41 @@
 
       <div class="post-content">
 
-        <p>Picture this. It's a Friday night and you're out with friends. The bar is good, the conversation is good, someone just ordered another round. Nobody is checking the time. The old version of you stays until 2am and feels vaguely terrible for the next two days. The version of you who has been serious about sleep for the past few months looks at the clock, sees it's 10:15, and starts doing the mental math.</p>
+        <p>You're at the door. Everyone else is staying. Someone asks if you're sure, with that particular tone that isn't quite questioning your judgment but is definitely registering it. You say yeah, you have to be up early, and you walk out, and the night air hits you, and for about fifteen minutes on the drive home you wonder whether this is a reasonable thing to do with your Friday night or whether you have become, quietly and without meaning to, a little boring.</p>
 
-        <p>And then you say it. "I should probably head out."</p>
+        <p>That feeling is the part nobody talks about in sleep optimization content. The sleep content industry has produced an enormous amount of useful material — light exposure, melatonin timing, bedroom temperature, sleep staging, circadian phase management. All of it is real. None of it touches the actual hard part, which is the social and psychological negotiation that happens the moment you decide your sleep schedule genuinely matters to you.</p>
 
-        <p>There's a beat. Someone says "already?" Someone else makes a joke about being old. You pull on your jacket and say your goodbyes and walk out into the night and the whole ride home you feel the specific, low-grade discomfort of having chosen sleep over a night out with people you actually like.</p>
+        <h2>What's actually being asked of you</h2>
 
-        <p>Nobody writes about that part.</p>
+        <p>The biology of good sleep is not, in the end, the obstacle. You can learn the mechanisms in an afternoon. The obstacle is that taking sleep seriously puts you in repeated, low-stakes social conflict with a world that treats late nights as the default expression of being engaged and fun and present. Coming home at 10pm is not the neutral choice — it reads, to almost everyone you leave behind, as a mild rejection, a priority statement, a slightly odd commitment that they respect without quite understanding.</p>
 
-        <p>The sleep content industry has produced an enormous amount of useful material on light exposure, melatonin timing, bedroom temperature, sleep staging, and circadian phase management. All of it is real. None of it is the hard part. The hard part is the social negotiation that comes the moment you decide your sleep schedule actually matters to you.</p>
+        <p>This is not aggressive pressure. Nobody is demanding you stay. It's the raised eyebrow when you pass on the late dinner, the "already?" delivered with just enough warmth that you can't really object to it, the joke about being old that you laugh at because what else are you going to do. The pressure is in the cumulative weight of those small moments, each one requiring you to hold your position without being weird about it.</p>
 
-        <h2>The friction nobody names</h2>
+        <p>And the holding is harder than it sounds, because a night out with people you like is not temptation in the pejorative sense. It's a real good. The discipline isn't about resisting something bad. It's about choosing one genuine good — the pattern of consistent sleep, the way your body and mind function when that pattern is intact — over another genuine good, the specific pleasure of staying when you're having a good time. That's a harder trade than saying no to the third drink.</p>
 
-        <p>There's a specific kind of social pressure that comes with taking sleep seriously. It's not aggressive. Nobody is actually demanding you stay out until 2am. It's subtler than that. It's the mild confusion people express when you decline plans that conflict with your schedule. It's the raised eyebrow when you pass on the late dinner. It's the "oh, you're one of those" energy when you explain, for the second time, that you need to be home by a certain hour.</p>
+        <h2>The Huberman framing that actually helps</h2>
 
-        <p>Most of us were raised in a culture where staying up late signals engagement and importance. Working late means you're dedicated. Going out late means you're fun. Coming home early means you're boring, or anxious, or something is wrong with you. None of this is stated directly. You just feel it.</p>
+        <p>Andrew Huberman talks about targeting six nights out of seven for your sleep schedule. One night a week, the social or life cost of rigid adherence may simply not be worth paying — a family dinner that runs late, a genuine celebration, a night where being present matters more than being on time for bed. The goal is not perfect adherence. It's principled consistency, which is different.</p>
 
-        <p>For shift workers, this cuts deeper. Your schedule is already inverted relative to the social world around you. You're sleeping when people want to make plans. You're awake at 3am when the house is quiet. Your entire social life has to negotiate around a schedule that most people don't fully understand, and there's a real cost to that — not just in logistics but in the slow accumulation of explaining yourself, of declining things, of showing up halfway when you know you should be in bed.</p>
+        <p>I find this framing useful not because it gives you permission to slip but because it defuses the all-or-nothing spiral that kills most sleep discipline efforts. The failure mode isn't laziness. It's the pattern where one late night becomes evidence that the whole system has collapsed, which produces the kind of demoralization that makes recovery harder, which produces another late night, and so on. Huberman's six-of-seven is a built-in mechanism against that — a way of holding the structure without making it so rigid that a single deviation destroys it.</p>
 
-        <h2>What you're actually choosing</h2>
+        <p>The distinction he draws matters: there's a difference between a deliberate exception and a capitulation. Deciding this particular dinner is worth a late night is the discipline working. Finding yourself at 1am having never consciously chosen to be there is the discipline being absent. One requires the same underlying conviction as every other early departure; it just arrives at a different answer.</p>
 
-        <p>The decision to leave early is not a sleep decision. It's a values decision. You're making a concrete, visible choice about what you're optimizing for. And that choice, made repeatedly in small social moments, is harder than any sleep protocol.</p>
+        <h2>The friction stays — something else changes</h2>
 
-        <p>People who are serious about their athletic performance understand this. People who are serious about their creative work understand this. Anyone who has tried to maintain a training schedule, a writing habit, or a strict dietary protocol has encountered the specific exhaustion of saying no to things that are not inherently bad, just incompatible with what you're trying to do. Sleep is no different — it just happens to be the one where the social cost is most visible, because the alternative (staying out, staying up, saying yes) is the default that everyone else is doing.</p>
+        <p>There is no level of commitment you reach where walking out at 10pm stops feeling slightly awkward. The "already?" doesn't stop. The mild jokes don't stop. The people in your life don't arrive at a sufficient understanding of your schedule that the friction disappears. That's worth stating plainly, because a lot of the discipline-oriented content implies that once you've internalized the right values, the discomfort resolves. It doesn't, not really.</p>
 
-        <p>This is worth saying plainly: the discipline of good sleep is not about willpower over temptation. A night out with people you love is not temptation. It's a real good. The discipline is about holding the line on a real good in service of a larger pattern — knowing that the cumulative effect of consistent sleep matters more than any individual night, and being willing to pay the social price for that.</p>
+        <p>What changes is the quality of the second-guessing on the drive home. Early on, it's mostly doubt — did I miss something, was that the right call, am I being slightly ridiculous about this. After a while, the doubt is still there but it's quieter and gets answered faster, because you have evidence. You've done this enough times to know what the next day feels like either way. The doubt becomes a formality rather than a genuine question.</p>
 
-        <h2>The 6-out-of-7 principle</h2>
+        <p>You're still going to stay too late sometimes. That's not failure — the pattern is what matters, not any individual night. The goal was never to become someone who doesn't feel the pull of staying. It's to know why you're leaving anyway.</p>
 
-        <p>Andrew Huberman talks about this in a way that has stuck with me. His framing, roughly, is this: try to maintain your sleep schedule six nights out of seven. One night a week, the social or life cost of rigidly enforcing the schedule may not be worth it. A late family dinner, a genuine celebration, a night where showing up matters more than sleeping on time — these are real. The goal is not perfect adherence. It's principled consistency.</p>
+        <h2>The shift worker version of this</h2>
 
-        <p>This framing is useful because it defuses the binary. The failure mode for most people trying to build sleep discipline isn't laziness — it's all-or-nothing thinking. One late night becomes proof that the whole system has failed. The shame or frustration that follows makes it harder to return to the schedule, which produces more deviation, which produces more shame. The spiral is familiar.</p>
+        <p>If you work nights or rotating shifts, every dimension of the above is harder and the stakes are higher. Your sleep window is already fighting your biology — you're sleeping during daylight, coming off a 24-hour call with cortisol still running, trying to be present for family on what is technically the middle of your working night. The social friction compounds on top of that. You're not just leaving a party early; you're explaining to people why you need to sleep at 10am on a Tuesday, why you can't make it to something at 7pm when your shift starts at 9, why you looked at a gathering of people you love and did the math and left.</p>
 
-        <p>The 6-out-of-7 idea gives you a built-in release valve without destroying the pattern. You're not a monk. You're a person trying to live a sustainable life in a world with other people in it. One night isn't the protocol failing. One night is the protocol working as designed — because a protocol you can never deviate from isn't sustainable, and something unsustainable doesn't actually protect your sleep long-term.</p>
+        <p>Most people try to understand and don't quite get there. The math of your schedule doesn't map onto theirs, and bridging that gap every time it comes up is its own form of exhaustion. The part you can control is how consistently you protect the window when you have one — and the degree to which you let other people's confusion become something you're responsible for managing.</p>
 
-        <p>The key is that the one night is a deliberate choice, not a capitulation. There's a difference between deciding "this particular dinner is worth a late night" and finding yourself at 1am having never consciously chosen to be there. The former is the discipline working. The latter is the discipline being absent.</p>
-
-        <h2>What actually changes</h2>
-
-        <p>The social friction doesn't go away. There's no level of conviction you reach where leaving early stops feeling slightly awkward. The "already?" doesn't stop. The mild jokes don't stop. That's worth stating plainly, because a lot of the productivity-oriented sleep content implies that once you're committed enough, the discomfort dissolves. It doesn't, really.</p>
-
-        <p>What does shift is the quality of your second-guessing. Early on, the ride home after leaving early is mostly doubt — did I miss something? was that worth it? am I being a little ridiculous? After a while, the doubt is still there but it's quieter, and it gets answered faster. You know what you're trading and why. You've done it enough times to have evidence either way.</p>
-
-        <p>You're still going to feel the pull sometimes. You're still going to stay too late occasionally, and it's fine, and you'll recover. The goal was never to become someone who doesn't feel FOMO. The goal is to know why you're leaving anyway, most of the time, and to not need a lot of internal debate to do it.</p>
-
-        <h2>A note for shift workers</h2>
-
-        <p>If you work nights or rotating shifts, the stakes here are higher and the logistics are messier. Your sleep window is already fighting biology — sleeping during daylight, coming off a 24-hour call with cortisol still elevated, trying to be present for family on what is technically the middle of your night. The social friction compounds on top of that. You're not just leaving a party early; you're explaining to people why you need to sleep at 10am on a Tuesday, or why you can't make it to something at 7pm when your shift starts at 9.</p>
-
-        <p>Most people try to understand and don't quite get there. That's fine. The math of your schedule genuinely doesn't map onto theirs. The part you can control is how consistently you protect your sleep window once you have one — and how much you let other people's confusion become your problem.</p>
-
-        <p>The <a href="/blog/posts/shift-worker-sleep-protocol.html">Shift Worker Sleep Protocol</a> covers the technical side of this. Light management, sleep timing, nap strategy, rotation recovery. The technical side matters. But it doesn't do much if you can't hold the window when everything else is pressing in on it.</p>
+        <p>The <a href="/blog/posts/shift-worker-sleep-protocol.html">Shift Worker Sleep Protocol</a> covers the technical side: light management, sleep timing, nap strategy, rotation recovery. That framework matters. But the technical side doesn't do much if you can't hold the window when your life is pressing in on it from every other direction.</p>
 
       </div>
 

--- a/scripts/editorial/style_guidelines.md
+++ b/scripts/editorial/style_guidelines.md
@@ -23,7 +23,19 @@
 
 ## Voice (with examples)
 
-Write like a sleep researcher explaining something to a friend over coffee. Not clinical. Not salesy. Just clear and helpful.
+Write like a knowledgeable human who is genuinely invested in the topic. Not a content machine. Not a wellness brand. Someone who has actually read the studies and thought about them.
+
+**Sentence structure**: Long, flowing sentences that build momentum across 3-4 clauses. Not short punchy fragments. Run a thought out fully before landing it. Vary rhythm deliberately — a long clause earns a short one.
+
+**Method**: Zoom in on one specific, concrete detail — a scenario, a moment, a small thing — and let it expand into the larger point. Don't start with the abstract thesis; start with the specific thing that contains it.
+
+**Claims**: Bold and direct. Make an interpretive claim and stand by it. Don't hedge everything or preface every point with "it's worth noting" or "arguably."
+
+**Voice**: First-person ("I") is natural in philosophical or opinion pieces. Earnest, genuinely invested, not ironic or detached.
+
+**Reader relationship**: Trust the reader's intelligence. Don't repeat what was just said. Make a connection and move on.
+
+**Endings**: Leave the reader with a tension or an open question. Not a neat bow. Not a motivational closer. Not "sleep well" or anything that sounds like a sign-off. Just where the thought actually lands.
 
 **BAD (generic AI):**
 > In today's fast-paced world, getting quality sleep is more important than ever. Studies have shown that sleep plays a crucial role in our overall health and well-being. Let's dive into the science behind sleep and discover how you can optimize your rest for better performance.
@@ -42,6 +54,13 @@ Write like a sleep researcher explaining something to a friend over coffee. Not 
 
 **GOOD (grounded, helpful):**
 > The military's 2-minute sleep technique dates back to a 1981 Navy pre-flight school manual. It works because it systematically addresses the three things keeping you awake: muscle tension, visual processing, and recursive thought. Here's the exact protocol.
+
+## What to strip from every post
+- Any sentence that starts with "It's worth noting", "It's important to understand", "In today's world", "In conclusion"
+- Any ending that wraps up too neatly or sounds like a motivational poster or sign-off
+- Listicle structure where flowing paragraphs would be stronger
+- Summary paragraphs that restate what the post already covered
+- Generic openers like "Sleep is important for..." or "We all know that..." or "Imagine coming home after a grueling shift..."
 
 ## Template Rotation (deterministic)
 Choose one format per post using `isoWeek % 6`:
@@ -106,4 +125,4 @@ Choose one format per post using `isoWeek % 6`:
 
 ## Tone
 - Direct, human, expert, practical. No corporate buzzwords. No "optimize" or "leverage."
-- Close with a short, grounded line. Example: "Rest well. Rise ready."
+- Close with a short, grounded line — where the thought actually lands. Not a motivational sign-off. Not "Rest well" or "Sleep tight" or anything that reads like ad copy.

--- a/scripts/generate-blog-post.mjs
+++ b/scripts/generate-blog-post.mjs
@@ -461,8 +461,11 @@ Return JSON:
   "inline_image_after_section": 2,
   "inline_image_prompt": "a second editorial image tied to this section's content. Be visually creative -- nature, science, workplace, urban, or abstract. NOT a bedroom or bed.",
   "inline_alt": "80-125 char descriptive alt text for inline image including primary keyword",
-  "closingLine": "short grounded closing line"
+  "voice_archetype": null,
+  "closingLine": "short grounded closing line — not a sign-off, not inspirational, just where the thought lands"
 }
+
+NOTE: voice_archetype is OPTIONAL. Set it only when the topic genuinely matches one of the four archetypes. Leave null for base SleepMedic voice.
 
 RULES:
 - 4-6 sections including intro hook and closing protocol
@@ -473,7 +476,14 @@ RULES:
 - inline_image_after_section: pick the section index where a visual would help most
 - Title must match what someone would search for. No clickbait.
 - cover_alt and inline_alt: descriptive, 80-125 chars, include the primary keyword phrase
-- If RELATED SEARCHES are provided, work at least 1-2 into section headings or content angles (these are real queries people type).`;
+- If RELATED SEARCHES are provided, work at least 1-2 into section headings or content angles (these are real queries people type).
+
+VOICE ARCHETYPE SELECTION — pick exactly one based on topic and template:
+- "scientist": mechanism-heavy posts, sleep biology, circadian science, memory, hormones. Curious, rigorous, dry wit. "Here's what's actually happening in your cells."
+- "monk": ritual, bedtime routines, NSDR, meditation, slow intentional practice. Still, philosophical, breathing room in the prose. No urgency.
+- "warrior": discipline posts, saying no, consistency habits, shift work survival. Direct, makes the hard ask, won't let you stew. Empathetic but no excuses.
+- "princess": self-worth posts, permission to rest, why sleep isn't laziness, caregiver burnout. Warm, affirming, addresses guilt without being saccharine.
+Do NOT default to warrior. Match the archetype to the topic.`;
 
   let outline = await gemini(planPrompt, { system, json: true, temp: 0.7 });
 
@@ -510,18 +520,54 @@ RULES:
 async function stage4_writeSections(outline, research, guidelines) {
   log(4, `Writing ${outline.sections.length} sections...`);
 
+  const archetypeDescriptions = {
+    scientist: `VOICE ARCHETYPE — SCIENTIST:
+Energy: curious, rigorous, finds the biology genuinely fascinating. Dry wit. Precise.
+Primary references: Matt Walker (Why We Sleep — memory consolidation, immune function, cancer risk, the cost of every lost hour of deep sleep) and Andrew Huberman (actionable neuroscience — light exposure protocols, cortisol timing, temperature manipulation, adenosine clearance). When in Scientist mode, the post should feel like it's in dialogue with their work — not citing them by name necessarily, but operating in the same register of "here is the mechanism, here is what to do with it."
+Secondary model: Mary Roach + Michael Easter. "Here's what's actually happening in your cells at 3am."
+Prose: long sentences that build through mechanism → implication → application. Names things accurately. Not clinical — engaged.
+What it is NOT: it is not lecturing. It is sharing something genuinely interesting.`,
+    monk: `VOICE ARCHETYPE — MONK:
+Energy: still, intentional, philosophical. Interested in ritual, presence, the quiet discipline of a life well-ordered. No urgency.
+Model: meditative essay, not a briefing. References contemplative traditions alongside the science.
+Prose: breathing room between ideas. Sentences land slowly. No bullet-point energy even in protocol sections.
+What it is NOT: it is not passive or vague. It is deeply intentional, just unhurried.`,
+    warrior: `VOICE ARCHETYPE — WARRIOR:
+Energy: disciplined, direct, won't let you stew in mediocrity. Empathetic but makes the hard ask. Ryan Holiday / Stoic energy.
+Model: "You know what you need to do. The question is whether you'll do it."
+Prose: short declarative sentences mixed into longer analytical ones. Commands are real commands. No hedging.
+What it is NOT: it is not harsh or dismissive. It respects the reader enough to be honest.`,
+    princess: `VOICE ARCHETYPE — PRINCESS:
+Energy: self-worth, care, permission. Addresses the reader who feels guilty for prioritizing sleep, who has been told rest is laziness.
+Model: warm, affirming without being saccharine. "You are not being selfish. You are being necessary."
+Prose: second-person that feels like a hand on the shoulder. Validates before prescribing. Specific and practical, not abstract affirmations.
+What it is NOT: it is not soft on the science. The warmth wraps rigorous advice, not platitudes.`
+  };
+
+  const archetypeNote = outline.voice_archetype
+    ? archetypeDescriptions[outline.voice_archetype] || ''
+    : '';
+
   const system = `You write for SleepMedic, a sleep science blog.
 Primary audience: anyone struggling with sleep.
 Core niche: shift workers (EMTs, nurses, firefighters).
 
 ${guidelines}
 
-Voice: warm, direct, expert. Like a sleep researcher explaining to a friend over coffee.
+${archetypeNote}
+
+CRAFT PRINCIPLES (apply to all archetypes):
+- Long flowing sentences that build momentum — run a thought fully before landing it
+- Start with one specific concrete detail (a scenario, a number, a moment) and let it expand
+- Make bold interpretive claims and stand by them — don't hedge everything
+- Trust the reader's intelligence. Don't repeat what you just said. Make a connection and move on.
+- First-person ("I") is natural when appropriate to the archetype and topic
+- Endings: leave with a tension or open question, not a neat bow or sign-off
 
 ${bannedPhrasesBlock()}
 
 STYLE:
-- Vary sentence length dramatically. Short punch. Then longer with detail.
+- Vary sentence length deliberately. A long analytical clause earns a short punchy one.
 - Use "you" directly. Never "one should."
 - Specific numbers: temps in F, durations in minutes, percentages.
 - Use contractions (don't, you'll, it's, can't).
@@ -630,7 +676,11 @@ function stage5_assemble(sections, outline) {
 async function stage6_edit(fullHtml, outline, guidelines) {
   log(6, 'Editing and polishing...');
 
+  const archetypeReminder = outline.voice_archetype ? `Voice archetype for this post: ${outline.voice_archetype}. Preserve the energy of that archetype throughout — do not flatten it into generic editorial voice.` : '';
+
   const system = `You are a senior editor at SleepMedic. Polish this draft so it reads like a knowledgeable human wrote it, not AI.
+
+${archetypeReminder}
 
 ${guidelines}
 
@@ -673,11 +723,12 @@ async function stage7_humanize(html, outline, guidelines) {
     `You are a writing coach. This blog post is good but still reads slightly like AI wrote it. Make it sound like a real human expert.
 
 Title: "${outline.title}"
+${outline.voice_archetype ? `Voice archetype: ${outline.voice_archetype} — preserve this energy throughout. Do not flatten it into generic editorial voice.` : 'Voice: base SleepMedic voice — knowledgeable, direct, human. Not a specific archetype.'}
 
 ${html}
 
 YOUR TASKS:
-1. Replace any remaining formal/stiff phrasing with conversational tone
+1. Replace any remaining formal/stiff phrasing with the energy of the archetype above
 2. Add 1-2 rhetorical questions where they feel natural (not forced)
 3. If there's no concrete scene or micro-story in the opening, add one (2-3 sentences max)
 4. Vary paragraph lengths more aggressively -- some should be just 1 sentence
@@ -686,12 +737,13 @@ YOUR TASKS:
 7. Make sure transitions between sections feel like natural thought progression, not "Next, let's discuss..."
 8. Keep all factual content, citations, protocols, and numbers exactly as they are
 9. Keep the <!-- INLINE_IMAGE_SLOT --> comment (do not remove)
+10. The closing line must NOT be a motivational sign-off or neat bow. End where the thought actually lands.
 
 ${bannedPhrasesBlock()}
 
 Return ONLY the improved HTML body. Same tag set. No meta commentary.`,
     {
-      system: `You write for SleepMedic. Voice: warm, direct, expert. Like explaining to a smart friend. ${guidelines.slice(0, 500)}`,
+      system: `You write for SleepMedic. ${outline.voice_archetype ? `Voice archetype: ${outline.voice_archetype}. Preserve that energy.` : 'Base SleepMedic voice — direct, specific, human.'} ${guidelines.slice(0, 500)}`,
       temp: 0.6,
       maxTokens: 10000
     }


### PR DESCRIPTION
## Summary

- Full voice pass on 20 posts: stripped motivational sign-offs, deleted Conclusion sections, rewrote generic \"Imagine...\" openers with direct specific prose
- 2026-04-16 philosophical post rewritten from scratch in Jaden's voice (concrete scene, no neat bow)
- Three posts received direct voice rewrites: warrior closing, cultural-practices intro, long-term-effects intro
- Generation pipeline: optional voice archetype system (scientist/monk/warrior/princess); null = base voice
- Scientist archetype updated to name Walker and Huberman as primary reference points
- Editorial guidelines updated with Jaden's voice profile and banned phrases list

## Test plan

- [ ] All modified post HTML is valid (no broken tags)
- [ ] No motivational sign-offs or \"Conclusion\" headings remain in modified files
- [ ] generate-blog-post.mjs: posts with null voice_archetype get base voice (no archetype injection)
- [ ] generate-blog-post.mjs: posts with voice_archetype set get correct energy block

🤖 Generated with [Claude Code](https://claude.com/claude-code)